### PR TITLE
Fixes for building on windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,7 +27,15 @@ foreach(TEST ${TESTS})
         cmocka
         copentime
         copentimelineio
-        pthread)
+        )
+
+    if (WIN32)
+        # don't link pthread
+    else()
+        target_link_libraries(C${TEST} PUBLIC
+            pthread
+            )
+    endif()
     target_compile_definitions(C${TEST} PRIVATE
         SAMPLE_DATA_DIR=${CMAKE_CURRENT_SOURCE_DIR}/sample_data/)
     add_test(NAME C${TEST} COMMAND C${TEST})

--- a/tests/OTIOCompositionTests.c
+++ b/tests/OTIOCompositionTests.c
@@ -2058,7 +2058,7 @@ static void otio_nesting_deeply_nesting_test(void **state) {
     assert_true(RationalTime_equal(stack_transformed_time_fifty_clip, middle));
     assert_true(RationalTime_equal(stack_transformed_time_ninetynine_clip, last));
 
-    int num_wrappers = 10;
+    #define num_wrappers 10
     Stack *wrappers[num_wrappers];
     struct ClipWrapperPair clipWrapperPair;
     clipWrapperPair.clip = clip;


### PR DESCRIPTION
Don't link to pthread on windows

Define a symbol instead of an int, MVSC can't see it as a constant (and gives an error).