### PR TITLE
Add a function to free allocated memory

### DIFF
--- a/include/copentime/util.h
+++ b/include/copentime/util.h
@@ -39,3 +39,5 @@ inline opentime::TimeTransform CTimeTransform_to_CppTimeTransform(TimeTransform 
     opentime::RationalTime offset = CRationalTime_to_CppRationalTime(timeTransform.offset);
     return opentime::TimeTransform(offset, timeTransform.scale, timeTransform.rate);
 }
+
+OTIO_API void Opentime_Free(void *ptr);

--- a/src/copentime/CMakeLists.txt
+++ b/src/copentime/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(copentime ${COTIO_SHARED_OR_STATIC_LIB}
         timeRange.cpp
         timeTransform.cpp
         optionalOpenTime.cpp
+        util.cpp
         ${PROJECT_SOURCE_DIR}/include/copentime/util.h
         ${COPENTIME_HEADER_FILES})
 

--- a/src/copentime/util.cpp
+++ b/src/copentime/util.cpp
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+#include "copentime/util.h"
+
+OTIO_API void Opentime_Free(void *ptr){
+    free(ptr);
+}


### PR DESCRIPTION
Managed runtimes like C# P/Invoke requires this in order to be able to correctly free memory in managed code that was allocated by unmanaged code.

The method was only defined in copentime because it can be used on it's own but opentimlineio must be used with opentime.