### PR TITLE
Add extern to global vars

### DIFF
--- a/include/copentimelineio/marker.h
+++ b/include/copentimelineio/marker.h
@@ -10,21 +10,27 @@
 
 #ifdef __cplusplus
 # define OTIO_API extern "C"
+# define OTIO_API_BEGIN OTIO_API {
+# define OTIO_API_END }
 #else
 # define OTIO_API
+# define OTIO_API_BEGIN
+# define OTIO_API_END
 #endif
 
-OTIO_API const char *MarkerColor_pink;
-OTIO_API const char *MarkerColor_red;
-OTIO_API const char *MarkerColor_orange;
-OTIO_API const char *MarkerColor_yellow;
-OTIO_API const char *MarkerColor_green;
-OTIO_API const char *MarkerColor_cyan;
-OTIO_API const char *MarkerColor_blue;
-OTIO_API const char *MarkerColor_purple;
-OTIO_API const char *MarkerColor_magenta;
-OTIO_API const char *MarkerColor_black;
-OTIO_API const char *MarkerColor_white;
+OTIO_API_BEGIN
+extern const char *MarkerColor_pink;
+extern const char *MarkerColor_red;
+extern const char *MarkerColor_orange;
+extern const char *MarkerColor_yellow;
+extern const char *MarkerColor_green;
+extern const char *MarkerColor_cyan;
+extern const char *MarkerColor_blue;
+extern const char *MarkerColor_purple;
+extern const char *MarkerColor_magenta;
+extern const char *MarkerColor_black;
+extern const char *MarkerColor_white;
+OTIO_API_END
 typedef struct RetainerMarker RetainerMarker;
 typedef struct Marker Marker;
 

--- a/include/copentimelineio/track.h
+++ b/include/copentimelineio/track.h
@@ -19,8 +19,12 @@
 
 #ifdef __cplusplus
 # define OTIO_API extern "C"
+# define OTIO_API_BEGIN OTIO_API {
+# define OTIO_API_END }
 #else
 # define OTIO_API
+# define OTIO_API_BEGIN
+# define OTIO_API_END
 #endif
 
 typedef struct Track Track;
@@ -31,8 +35,10 @@ typedef enum {
 } OTIO_Track_NeighbourGapPolicy_;
 typedef int OTIO_Track_NeighbourGapPolicy;
 
-OTIO_API const char *TrackKind_Video;
-OTIO_API const char *TrackKind_Audio;
+OTIO_API_BEGIN
+extern const char *TrackKind_Video;
+extern const char *TrackKind_Audio;
+OTIO_API_END
 
 OTIO_API Track *Track_create(
         const char *name,


### PR DESCRIPTION
Doing some searching it seems that ```extern``` and ```extern "C"``` are not the same; the first declares that something has external linkage, while the second declares that the symbols are not mangled in C++. This PR hopefully fixes #22 by adding ```extern``` to the global variables, along with ```extern "C"``` when compiling with C++.

To use ```extern``` with ```extern "C"``` I needed to add curly brackets, so I created a couple of new macros for defining a block of statements as ```extern "C"```.