### PR TITLE
Fixes for MSVC warnings

### DIFF
--- a/include/copentime/util.h
+++ b/include/copentime/util.h
@@ -9,8 +9,6 @@
 #include <opentime/rationalTime.h>
 #include <opentime/timeRange.h>
 #include <opentime/timeTransform.h>
-#include <stdlib.h>
-#include <string.h>
 
 inline RationalTime CppRationalTime_to_CRationalTime(opentime::RationalTime rationalTime) {
     return RationalTime_create(rationalTime.value(), rationalTime.rate());

--- a/include/copentime/util.h
+++ b/include/copentime/util.h
@@ -41,12 +41,3 @@ inline opentime::TimeTransform CTimeTransform_to_CppTimeTransform(TimeTransform 
     opentime::RationalTime offset = CRationalTime_to_CppRationalTime(timeTransform.offset);
     return opentime::TimeTransform(offset, timeTransform.scale, timeTransform.rate);
 }
-
-inline char* CppString_to_CString(std::string const& s)
-{
-    const size_t size = s.size();
-    char* charPtr = (char*)malloc((size + 1) * sizeof(char));
-    memcpy(charPtr, s.c_str(), size);
-    charPtr[size] = 0;
-    return charPtr;
-}

--- a/include/copentime/util.h
+++ b/include/copentime/util.h
@@ -9,6 +9,8 @@
 #include <opentime/rationalTime.h>
 #include <opentime/timeRange.h>
 #include <opentime/timeTransform.h>
+#include <stdlib.h>
+#include <string.h>
 
 inline RationalTime CppRationalTime_to_CRationalTime(opentime::RationalTime rationalTime) {
     return RationalTime_create(rationalTime.value(), rationalTime.rate());
@@ -38,4 +40,12 @@ inline TimeTransform CppTimeTransform_to_CTimeTransform(opentime::TimeTransform 
 inline opentime::TimeTransform CTimeTransform_to_CppTimeTransform(TimeTransform timeTransform) {
     opentime::RationalTime offset = CRationalTime_to_CppRationalTime(timeTransform.offset);
     return opentime::TimeTransform(offset, timeTransform.scale, timeTransform.rate);
+}
+
+inline char* CppString_to_CString(std::string const& s)
+{
+    const size_t size = s.size() + 1;
+    char* charPtr = (char*)malloc(size * sizeof(char));
+    strcpy_s(charPtr, size, s.c_str());
+    return charPtr;
 }

--- a/include/copentime/util.h
+++ b/include/copentime/util.h
@@ -44,8 +44,9 @@ inline opentime::TimeTransform CTimeTransform_to_CppTimeTransform(TimeTransform 
 
 inline char* CppString_to_CString(std::string const& s)
 {
-    const size_t size = s.size() + 1;
-    char* charPtr = (char*)malloc(size * sizeof(char));
+    const size_t size = s.size();
+    char* charPtr = (char*)malloc((size + 1) * sizeof(char));
     memcpy(charPtr, s.c_str(), size);
+    charPtr[size] = 0;
     return charPtr;
 }

--- a/include/copentime/util.h
+++ b/include/copentime/util.h
@@ -46,6 +46,6 @@ inline char* CppString_to_CString(std::string const& s)
 {
     const size_t size = s.size() + 1;
     char* charPtr = (char*)malloc(size * sizeof(char));
-    strcpy_s(charPtr, size, s.c_str());
+    memcpy(charPtr, s.c_str(), size);
     return charPtr;
 }

--- a/include/copentimelineio/unknownSchema.h
+++ b/include/copentimelineio/unknownSchema.h
@@ -12,7 +12,7 @@
 # define OTIO_API
 #endif
 
-typedef struct UnknownSchema UnknownSchema;
+typedef class UnknownSchema UnknownSchema;
 
 OTIO_API UnknownSchema *UnknownSchema_create(
         const char *original_schema_name, int original_schema_version);

--- a/src/copentime/CMakeLists.txt
+++ b/src/copentime/CMakeLists.txt
@@ -20,6 +20,8 @@ target_include_directories(copentime PUBLIC
 
 target_link_libraries(copentime opentime)
 
+target_compile_definitions(copentime PRIVATE _CRT_SECURE_NO_WARNINGS)
+
 set_target_properties(copentime PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
         MACOSX_RPATH true WINDOWS_EXPORT_ALL_SYMBOLS true)
 

--- a/src/copentime/CMakeLists.txt
+++ b/src/copentime/CMakeLists.txt
@@ -20,8 +20,6 @@ target_include_directories(copentime PUBLIC
 
 target_link_libraries(copentime opentime)
 
-target_compile_definitions(copentime PRIVATE _CRT_SECURE_NO_WARNINGS)
-
 set_target_properties(copentime PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
         MACOSX_RPATH true WINDOWS_EXPORT_ALL_SYMBOLS true)
 

--- a/src/copentime/CMakeLists.txt
+++ b/src/copentime/CMakeLists.txt
@@ -20,6 +20,10 @@ target_include_directories(copentime PUBLIC
 
 target_link_libraries(copentime opentime)
 
+if(WIN32)
+    target_compile_definitions(copentime PRIVATE _CRT_NONSTDC_NO_WARNINGS)
+endif()
+
 set_target_properties(copentime PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
         MACOSX_RPATH true WINDOWS_EXPORT_ALL_SYMBOLS true)
 

--- a/src/copentime/errorStatus.cpp
+++ b/src/copentime/errorStatus.cpp
@@ -2,8 +2,8 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentime/errorStatus.h"
+#include "copentime/util.h"
 #include <opentime/errorStatus.h>
-#include <string.h>
 
 OTIO_API OpenTimeErrorStatus *OpenTimeErrorStatus_create() {
     return reinterpret_cast<OpenTimeErrorStatus *>(
@@ -24,9 +24,7 @@ OTIO_API const char *OpenTimeErrorStatus_outcome_to_string(
         OpenTimeErrorStatus *self, OpenTime_ErrorStatus_Outcome var1) {
     std::string returnStr = opentime::ErrorStatus::outcome_to_string(
             static_cast<opentime::ErrorStatus::Outcome>(var1));
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 OTIO_API void OpenTimeErrorStatus_destroy(OpenTimeErrorStatus *self) {
     delete reinterpret_cast<opentime::ErrorStatus *>(self);

--- a/src/copentime/errorStatus.cpp
+++ b/src/copentime/errorStatus.cpp
@@ -24,7 +24,7 @@ OTIO_API const char *OpenTimeErrorStatus_outcome_to_string(
         OpenTimeErrorStatus *self, OpenTime_ErrorStatus_Outcome var1) {
     std::string returnStr = opentime::ErrorStatus::outcome_to_string(
             static_cast<opentime::ErrorStatus::Outcome>(var1));
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 OTIO_API void OpenTimeErrorStatus_destroy(OpenTimeErrorStatus *self) {
     delete reinterpret_cast<opentime::ErrorStatus *>(self);

--- a/src/copentime/errorStatus.cpp
+++ b/src/copentime/errorStatus.cpp
@@ -24,7 +24,7 @@ OTIO_API const char *OpenTimeErrorStatus_outcome_to_string(
         OpenTimeErrorStatus *self, OpenTime_ErrorStatus_Outcome var1) {
     std::string returnStr = opentime::ErrorStatus::outcome_to_string(
             static_cast<opentime::ErrorStatus::Outcome>(var1));
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 OTIO_API void OpenTimeErrorStatus_destroy(OpenTimeErrorStatus *self) {
     delete reinterpret_cast<opentime::ErrorStatus *>(self);

--- a/src/copentime/errorStatus.cpp
+++ b/src/copentime/errorStatus.cpp
@@ -2,8 +2,8 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentime/errorStatus.h"
-#include "copentime/util.h"
 #include <opentime/errorStatus.h>
+#include <string.h>
 
 OTIO_API OpenTimeErrorStatus *OpenTimeErrorStatus_create() {
     return reinterpret_cast<OpenTimeErrorStatus *>(

--- a/src/copentime/rationalTime.cpp
+++ b/src/copentime/rationalTime.cpp
@@ -128,7 +128,7 @@ OTIO_API const char *RationalTime_to_timecode(
                     rate,
                     static_cast<opentime::IsDropFrameRate>(drop_frame),
                     reinterpret_cast<opentime::ErrorStatus *>(error_status));
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 
 OTIO_API const char *RationalTime_to_timecode_auto(
@@ -136,13 +136,13 @@ OTIO_API const char *RationalTime_to_timecode_auto(
     opentime::RationalTime ot_self = CRationalTime_to_CppRationalTime(self);
     std::string returnStr = ot_self.to_timecode(
             reinterpret_cast<opentime::ErrorStatus *>(error_status));
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 
 OTIO_API const char *RationalTime_to_time_string(RationalTime self) {
     opentime::RationalTime ot_self = CRationalTime_to_CppRationalTime(self);
     std::string returnStr = ot_self.to_time_string();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 
 OTIO_API RationalTime RationalTime_add(RationalTime lhs, RationalTime rhs) {

--- a/src/copentime/rationalTime.cpp
+++ b/src/copentime/rationalTime.cpp
@@ -129,7 +129,7 @@ OTIO_API const char *RationalTime_to_timecode(
                     rate,
                     static_cast<opentime::IsDropFrameRate>(drop_frame),
                     reinterpret_cast<opentime::ErrorStatus *>(error_status));
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 
 OTIO_API const char *RationalTime_to_timecode_auto(
@@ -137,13 +137,13 @@ OTIO_API const char *RationalTime_to_timecode_auto(
     opentime::RationalTime ot_self = CRationalTime_to_CppRationalTime(self);
     std::string returnStr = ot_self.to_timecode(
             reinterpret_cast<opentime::ErrorStatus *>(error_status));
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 
 OTIO_API const char *RationalTime_to_time_string(RationalTime self) {
     opentime::RationalTime ot_self = CRationalTime_to_CppRationalTime(self);
     std::string returnStr = ot_self.to_time_string();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 
 OTIO_API RationalTime RationalTime_add(RationalTime lhs, RationalTime rhs) {

--- a/src/copentime/rationalTime.cpp
+++ b/src/copentime/rationalTime.cpp
@@ -4,7 +4,6 @@
 #include "copentime/rationalTime.h"
 #include "copentime/util.h"
 #include <opentime/rationalTime.h>
-#include <string.h>
 
 OTIO_API RationalTime RationalTime_create(double value, double rate) {
     RationalTime rationalTime;
@@ -129,9 +128,7 @@ OTIO_API const char *RationalTime_to_timecode(
                     rate,
                     static_cast<opentime::IsDropFrameRate>(drop_frame),
                     reinterpret_cast<opentime::ErrorStatus *>(error_status));
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 
 OTIO_API const char *RationalTime_to_timecode_auto(
@@ -139,17 +136,13 @@ OTIO_API const char *RationalTime_to_timecode_auto(
     opentime::RationalTime ot_self = CRationalTime_to_CppRationalTime(self);
     std::string returnStr = ot_self.to_timecode(
             reinterpret_cast<opentime::ErrorStatus *>(error_status));
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 
 OTIO_API const char *RationalTime_to_time_string(RationalTime self) {
     opentime::RationalTime ot_self = CRationalTime_to_CppRationalTime(self);
     std::string returnStr = ot_self.to_time_string();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 
 OTIO_API RationalTime RationalTime_add(RationalTime lhs, RationalTime rhs) {

--- a/src/copentime/rationalTime.cpp
+++ b/src/copentime/rationalTime.cpp
@@ -4,6 +4,7 @@
 #include "copentime/rationalTime.h"
 #include "copentime/util.h"
 #include <opentime/rationalTime.h>
+#include <string.h>
 
 OTIO_API RationalTime RationalTime_create(double value, double rate) {
     RationalTime rationalTime;

--- a/src/copentimelineio/CMakeLists.txt
+++ b/src/copentimelineio/CMakeLists.txt
@@ -103,6 +103,8 @@ target_link_libraries(copentimelineio
         opentimelineio
         copentime)
 
+target_compile_definitions(copentimelineio PRIVATE _CRT_SECURE_NO_WARNINGS)
+
 set_target_properties(copentimelineio PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
         MACOSX_RPATH true WINDOWS_EXPORT_ALL_SYMBOLS true)
 

--- a/src/copentimelineio/CMakeLists.txt
+++ b/src/copentimelineio/CMakeLists.txt
@@ -103,8 +103,6 @@ target_link_libraries(copentimelineio
         opentimelineio
         copentime)
 
-target_compile_definitions(copentimelineio PRIVATE _CRT_SECURE_NO_WARNINGS)
-
 set_target_properties(copentimelineio PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
         MACOSX_RPATH true WINDOWS_EXPORT_ALL_SYMBOLS true)
 

--- a/src/copentimelineio/CMakeLists.txt
+++ b/src/copentimelineio/CMakeLists.txt
@@ -103,6 +103,10 @@ target_link_libraries(copentimelineio
         opentimelineio
         copentime)
 
+if(WIN32)
+    target_compile_definitions(copentimelineio PRIVATE _CRT_NONSTDC_NO_WARNINGS)
+endif()
+
 set_target_properties(copentimelineio PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
         MACOSX_RPATH true WINDOWS_EXPORT_ALL_SYMBOLS true)
 

--- a/src/copentimelineio/anyDictionary.cpp
+++ b/src/copentimelineio/anyDictionary.cpp
@@ -114,7 +114,7 @@ OTIO_API const char* AnyDictionaryIterator_key(AnyDictionaryIterator* iter)
 {
     std::string returnStr =
         (*reinterpret_cast<DictionaryIterator*>(iter))->first;
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 OTIO_API Any* AnyDictionaryIterator_value(AnyDictionaryIterator* iter)
 {

--- a/src/copentimelineio/anyDictionary.cpp
+++ b/src/copentimelineio/anyDictionary.cpp
@@ -2,9 +2,9 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/anyDictionary.h"
-#include "copentime/util.h"
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/version.h>
+#include <string.h>
 
 typedef std::map<std::string, OTIO_NS::any>::iterator DictionaryIterator;
 

--- a/src/copentimelineio/anyDictionary.cpp
+++ b/src/copentimelineio/anyDictionary.cpp
@@ -114,7 +114,7 @@ OTIO_API const char* AnyDictionaryIterator_key(AnyDictionaryIterator* iter)
 {
     std::string returnStr =
         (*reinterpret_cast<DictionaryIterator*>(iter))->first;
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 OTIO_API Any* AnyDictionaryIterator_value(AnyDictionaryIterator* iter)
 {

--- a/src/copentimelineio/anyDictionary.cpp
+++ b/src/copentimelineio/anyDictionary.cpp
@@ -2,9 +2,9 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/anyDictionary.h"
+#include "copentime/util.h"
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/version.h>
-#include <string.h>
 
 typedef std::map<std::string, OTIO_NS::any>::iterator DictionaryIterator;
 
@@ -58,15 +58,15 @@ OTIO_API AnyDictionaryIterator* AnyDictionary_erase_range(
 }
 OTIO_API int AnyDictionary_erase_key(AnyDictionary* self, const char* key)
 {
-    return reinterpret_cast<OTIO_NS::AnyDictionary*>(self)->erase(key);
+    return static_cast<int>(reinterpret_cast<OTIO_NS::AnyDictionary*>(self)->erase(key));
 }
 OTIO_API int AnyDictionary_size(AnyDictionary* self)
 {
-    return reinterpret_cast<OTIO_NS::AnyDictionary*>(self)->size();
+    return static_cast<int>(reinterpret_cast<OTIO_NS::AnyDictionary*>(self)->size());
 }
 OTIO_API int AnyDictionary_max_size(AnyDictionary* self)
 {
-    return reinterpret_cast<OTIO_NS::AnyDictionary*>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<OTIO_NS::AnyDictionary*>(self)->max_size());
 }
 OTIO_API bool AnyDictionary_empty(AnyDictionary* self)
 {
@@ -114,9 +114,7 @@ OTIO_API const char* AnyDictionaryIterator_key(AnyDictionaryIterator* iter)
 {
     std::string returnStr =
         (*reinterpret_cast<DictionaryIterator*>(iter))->first;
-    char* charPtr = (char*) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 OTIO_API Any* AnyDictionaryIterator_value(AnyDictionaryIterator* iter)
 {

--- a/src/copentimelineio/anyVector.cpp
+++ b/src/copentimelineio/anyVector.cpp
@@ -26,15 +26,15 @@ OTIO_API AnyVectorIterator *AnyVector_end(AnyVector *self) {
 }
 
 OTIO_API int AnyVector_size(AnyVector *self) {
-    return reinterpret_cast<OTIO_NS::AnyVector *>(self)->size();
+    return static_cast<int>(reinterpret_cast<OTIO_NS::AnyVector *>(self)->size());
 }
 
 OTIO_API int AnyVector_max_size(AnyVector *self) {
-    return reinterpret_cast<OTIO_NS::AnyVector *>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<OTIO_NS::AnyVector *>(self)->max_size());
 }
 
 OTIO_API int AnyVector_capacity(AnyVector *self) {
-    return reinterpret_cast<OTIO_NS::AnyVector *>(self)->capacity();
+    return static_cast<int>(reinterpret_cast<OTIO_NS::AnyVector *>(self)->capacity());
 }
 
 OTIO_API void AnyVector_resize(AnyVector *self, int n) {

--- a/src/copentimelineio/composableRetainerVector.cpp
+++ b/src/copentimelineio/composableRetainerVector.cpp
@@ -39,15 +39,15 @@ ComposableRetainerVector_end(ComposableRetainerVector* self)
 }
 OTIO_API int ComposableRetainerVector_size(ComposableRetainerVector* self)
 {
-    return reinterpret_cast<ComposableRetainerVectorDef*>(self)->size();
+    return static_cast<int>(reinterpret_cast<ComposableRetainerVectorDef*>(self)->size());
 }
 OTIO_API int ComposableRetainerVector_max_size(ComposableRetainerVector* self)
 {
-    return reinterpret_cast<ComposableRetainerVectorDef*>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<ComposableRetainerVectorDef*>(self)->max_size());
 }
 OTIO_API int ComposableRetainerVector_capacity(ComposableRetainerVector* self)
 {
-    return reinterpret_cast<ComposableRetainerVectorDef*>(self)->capacity();
+    return static_cast<int>(reinterpret_cast<ComposableRetainerVectorDef*>(self)->capacity());
 }
 OTIO_API void ComposableRetainerVector_resize(ComposableRetainerVector* self, int n)
 {

--- a/src/copentimelineio/composableVector.cpp
+++ b/src/copentimelineio/composableVector.cpp
@@ -32,15 +32,15 @@ OTIO_API ComposableVectorIterator* ComposableVector_end(ComposableVector* self)
 }
 OTIO_API int ComposableVector_size(ComposableVector* self)
 {
-    return reinterpret_cast<ComposableVectorDef*>(self)->size();
+    return static_cast<int>(reinterpret_cast<ComposableVectorDef*>(self)->size());
 }
 OTIO_API int ComposableVector_max_size(ComposableVector* self)
 {
-    return reinterpret_cast<ComposableVectorDef*>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<ComposableVectorDef*>(self)->max_size());
 }
 OTIO_API int ComposableVector_capacity(ComposableVector* self)
 {
-    return reinterpret_cast<ComposableVectorDef*>(self)->capacity();
+    return static_cast<int>(reinterpret_cast<ComposableVectorDef*>(self)->capacity());
 }
 OTIO_API void ComposableVector_resize(ComposableVector* self, int n)
 {

--- a/src/copentimelineio/composition.cpp
+++ b/src/copentimelineio/composition.cpp
@@ -73,7 +73,7 @@ OTIO_API Composition *Composition_create(
 OTIO_API const char *Composition_composition_kind(Composition *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Composition *>(self)->composition_kind();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 OTIO_API ComposableRetainerVector *Composition_children(Composition *self) {
     ComposableRetainerVectorDef composableRetainerVector =

--- a/src/copentimelineio/composition.cpp
+++ b/src/copentimelineio/composition.cpp
@@ -72,7 +72,7 @@ OTIO_API Composition *Composition_create(
 OTIO_API const char *Composition_composition_kind(Composition *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Composition *>(self)->composition_kind();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 OTIO_API ComposableRetainerVector *Composition_children(Composition *self) {
     ComposableRetainerVectorDef composableRetainerVector =

--- a/src/copentimelineio/composition.cpp
+++ b/src/copentimelineio/composition.cpp
@@ -13,6 +13,7 @@
 #include <opentimelineio/effect.h>
 #include <opentimelineio/errorStatus.h>
 #include <opentimelineio/marker.h>
+#include <string.h>
 #include <utility>
 #include <vector>
 

--- a/src/copentimelineio/composition.cpp
+++ b/src/copentimelineio/composition.cpp
@@ -13,7 +13,6 @@
 #include <opentimelineio/effect.h>
 #include <opentimelineio/errorStatus.h>
 #include <opentimelineio/marker.h>
-#include <string.h>
 #include <utility>
 #include <vector>
 
@@ -73,9 +72,7 @@ OTIO_API Composition *Composition_create(
 OTIO_API const char *Composition_composition_kind(Composition *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Composition *>(self)->composition_kind();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 OTIO_API ComposableRetainerVector *Composition_children(Composition *self) {
     ComposableRetainerVectorDef composableRetainerVector =

--- a/src/copentimelineio/effect.cpp
+++ b/src/copentimelineio/effect.cpp
@@ -2,11 +2,11 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/effect.h"
+#include "copentime/util.h"
 #include <copentimelineio/serializableObjectWithMetadata.h>
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/effect.h>
 #include <opentimelineio/serializableObject.h>
-#include <string.h>
 
 typedef OTIO_NS::SerializableObject::Retainer<OTIO_NS::Effect> EffectRetainer;
 
@@ -49,9 +49,7 @@ OTIO_API Effect *Effect_create(
 OTIO_API const char *Effect_effect_name(Effect *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Effect *>(self)->effect_name();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 
 OTIO_API void Effect_set_effect_name(Effect *self, const char *effect_name) {

--- a/src/copentimelineio/effect.cpp
+++ b/src/copentimelineio/effect.cpp
@@ -49,7 +49,7 @@ OTIO_API Effect *Effect_create(
 OTIO_API const char *Effect_effect_name(Effect *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Effect *>(self)->effect_name();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 
 OTIO_API void Effect_set_effect_name(Effect *self, const char *effect_name) {

--- a/src/copentimelineio/effect.cpp
+++ b/src/copentimelineio/effect.cpp
@@ -2,11 +2,11 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/effect.h"
-#include "copentime/util.h"
 #include <copentimelineio/serializableObjectWithMetadata.h>
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/effect.h>
 #include <opentimelineio/serializableObject.h>
+#include <string.h>
 
 typedef OTIO_NS::SerializableObject::Retainer<OTIO_NS::Effect> EffectRetainer;
 

--- a/src/copentimelineio/effect.cpp
+++ b/src/copentimelineio/effect.cpp
@@ -49,7 +49,7 @@ OTIO_API Effect *Effect_create(
 OTIO_API const char *Effect_effect_name(Effect *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Effect *>(self)->effect_name();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 
 OTIO_API void Effect_set_effect_name(Effect *self, const char *effect_name) {

--- a/src/copentimelineio/effectRetainerVector.cpp
+++ b/src/copentimelineio/effectRetainerVector.cpp
@@ -37,15 +37,15 @@ EffectRetainerVector_end(EffectRetainerVector *self) {
 }
 
 OTIO_API int EffectRetainerVector_size(EffectRetainerVector *self) {
-    return reinterpret_cast<EffectRetainerVectorDef *>(self)->size();
+    return static_cast<int>(reinterpret_cast<EffectRetainerVectorDef *>(self)->size());
 }
 
 OTIO_API int EffectRetainerVector_max_size(EffectRetainerVector *self) {
-    return reinterpret_cast<EffectRetainerVectorDef *>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<EffectRetainerVectorDef *>(self)->max_size());
 }
 
 OTIO_API int EffectRetainerVector_capacity(EffectRetainerVector *self) {
-    return reinterpret_cast<EffectRetainerVectorDef *>(self)->capacity();
+    return static_cast<int>(reinterpret_cast<EffectRetainerVectorDef *>(self)->capacity());
 }
 
 OTIO_API void EffectRetainerVector_resize(EffectRetainerVector *self, int n) {

--- a/src/copentimelineio/effectVector.cpp
+++ b/src/copentimelineio/effectVector.cpp
@@ -31,15 +31,15 @@ OTIO_API EffectVectorIterator *EffectVector_end(EffectVector *self) {
 }
 
 OTIO_API int EffectVector_size(EffectVector *self) {
-    return reinterpret_cast<EffectVectorDef *>(self)->size();
+    return static_cast<int>(reinterpret_cast<EffectVectorDef *>(self)->size());
 }
 
 OTIO_API int EffectVector_max_size(EffectVector *self) {
-    return reinterpret_cast<EffectVectorDef *>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<EffectVectorDef *>(self)->max_size());
 }
 
 OTIO_API int EffectVector_capacity(EffectVector *self) {
-    return reinterpret_cast<EffectVectorDef *>(self)->capacity();
+    return static_cast<int>(reinterpret_cast<EffectVectorDef *>(self)->capacity());
 }
 
 OTIO_API void EffectVector_resize(EffectVector *self, int n) {

--- a/src/copentimelineio/errorStatus.cpp
+++ b/src/copentimelineio/errorStatus.cpp
@@ -35,7 +35,7 @@ OTIOErrorStatus_outcome_to_string(OTIO_ErrorStatus_Outcome var1)
 {
     std::string returnStr = OTIO_NS::ErrorStatus::outcome_to_string(
         static_cast<OTIO_NS::ErrorStatus::Outcome>(var1));
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 
 OTIO_API OTIO_ErrorStatus_Outcome

--- a/src/copentimelineio/errorStatus.cpp
+++ b/src/copentimelineio/errorStatus.cpp
@@ -2,8 +2,8 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/errorStatus.h"
+#include "copentime/util.h"
 #include <opentimelineio/errorStatus.h>
-#include <string.h>
 
 OTIO_API OTIOErrorStatus*
 OTIOErrorStatus_create()
@@ -35,9 +35,7 @@ OTIOErrorStatus_outcome_to_string(OTIO_ErrorStatus_Outcome var1)
 {
     std::string returnStr = OTIO_NS::ErrorStatus::outcome_to_string(
         static_cast<OTIO_NS::ErrorStatus::Outcome>(var1));
-    char* charPtr = (char*) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 
 OTIO_API OTIO_ErrorStatus_Outcome

--- a/src/copentimelineio/errorStatus.cpp
+++ b/src/copentimelineio/errorStatus.cpp
@@ -2,8 +2,8 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/errorStatus.h"
-#include "copentime/util.h"
 #include <opentimelineio/errorStatus.h>
+#include <string.h>
 
 OTIO_API OTIOErrorStatus*
 OTIOErrorStatus_create()

--- a/src/copentimelineio/errorStatus.cpp
+++ b/src/copentimelineio/errorStatus.cpp
@@ -35,7 +35,7 @@ OTIOErrorStatus_outcome_to_string(OTIO_ErrorStatus_Outcome var1)
 {
     std::string returnStr = OTIO_NS::ErrorStatus::outcome_to_string(
         static_cast<OTIO_NS::ErrorStatus::Outcome>(var1));
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 
 OTIO_API OTIO_ErrorStatus_Outcome

--- a/src/copentimelineio/externalReference.cpp
+++ b/src/copentimelineio/externalReference.cpp
@@ -34,7 +34,7 @@ OTIO_API ExternalReference *ExternalReference_create(
 OTIO_API const char *ExternalReference_target_url(ExternalReference *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::ExternalReference *>(self)->target_url();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 
 OTIO_API void ExternalReference_set_target_url(

--- a/src/copentimelineio/externalReference.cpp
+++ b/src/copentimelineio/externalReference.cpp
@@ -35,7 +35,7 @@ OTIO_API ExternalReference *ExternalReference_create(
 OTIO_API const char *ExternalReference_target_url(ExternalReference *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::ExternalReference *>(self)->target_url();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 
 OTIO_API void ExternalReference_set_target_url(

--- a/src/copentimelineio/externalReference.cpp
+++ b/src/copentimelineio/externalReference.cpp
@@ -9,7 +9,6 @@
 #include <opentime/timeRange.h>
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/externalReference.h>
-#include <string.h>
 
 OTIO_API ExternalReference *ExternalReference_create(
         const char *target_url,
@@ -35,9 +34,7 @@ OTIO_API ExternalReference *ExternalReference_create(
 OTIO_API const char *ExternalReference_target_url(ExternalReference *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::ExternalReference *>(self)->target_url();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 
 OTIO_API void ExternalReference_set_target_url(

--- a/src/copentimelineio/externalReference.cpp
+++ b/src/copentimelineio/externalReference.cpp
@@ -9,6 +9,7 @@
 #include <opentime/timeRange.h>
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/externalReference.h>
+#include <string.h>
 
 OTIO_API ExternalReference *ExternalReference_create(
         const char *target_url,

--- a/src/copentimelineio/generatorReference.cpp
+++ b/src/copentimelineio/generatorReference.cpp
@@ -47,7 +47,7 @@ OTIO_API const char *GeneratorReference_generator_kind(GeneratorReference *self)
     std::string returnStr =
             reinterpret_cast<OTIO_NS::GeneratorReference *>(self)
                     ->generator_kind();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 OTIO_API void GeneratorReference_set_generator_kind(
         GeneratorReference *self, const char *generator_kind) {

--- a/src/copentimelineio/generatorReference.cpp
+++ b/src/copentimelineio/generatorReference.cpp
@@ -8,6 +8,7 @@
 #include <opentime/timeRange.h>
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/generatorReference.h>
+#include <string.h>
 
 OTIO_API GeneratorReference *GeneratorReference_create(
         const char *name,

--- a/src/copentimelineio/generatorReference.cpp
+++ b/src/copentimelineio/generatorReference.cpp
@@ -8,7 +8,6 @@
 #include <opentime/timeRange.h>
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/generatorReference.h>
-#include <string.h>
 
 OTIO_API GeneratorReference *GeneratorReference_create(
         const char *name,
@@ -48,9 +47,7 @@ OTIO_API const char *GeneratorReference_generator_kind(GeneratorReference *self)
     std::string returnStr =
             reinterpret_cast<OTIO_NS::GeneratorReference *>(self)
                     ->generator_kind();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 OTIO_API void GeneratorReference_set_generator_kind(
         GeneratorReference *self, const char *generator_kind) {

--- a/src/copentimelineio/generatorReference.cpp
+++ b/src/copentimelineio/generatorReference.cpp
@@ -48,7 +48,7 @@ OTIO_API const char *GeneratorReference_generator_kind(GeneratorReference *self)
     std::string returnStr =
             reinterpret_cast<OTIO_NS::GeneratorReference *>(self)
                     ->generator_kind();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 OTIO_API void GeneratorReference_set_generator_kind(
         GeneratorReference *self, const char *generator_kind) {

--- a/src/copentimelineio/mapComposableTimeRange.cpp
+++ b/src/copentimelineio/mapComposableTimeRange.cpp
@@ -63,16 +63,16 @@ OTIO_API MapComposableTimeRangeIterator *MapComposableTimeRange_erase_range(
 
 OTIO_API int MapComposableTimeRange_erase_key(
         MapComposableTimeRange *self, Composable *key) {
-    return reinterpret_cast<MapDef *>(self)->erase(
-            reinterpret_cast<OTIO_NS::Composable *>(key));
+    return static_cast<int>(reinterpret_cast<MapDef *>(self)->erase(
+            reinterpret_cast<OTIO_NS::Composable *>(key)));
 }
 
 OTIO_API int MapComposableTimeRange_size(MapComposableTimeRange *self) {
-    return reinterpret_cast<MapDef *>(self)->size();
+    return static_cast<int>(reinterpret_cast<MapDef *>(self)->size());
 }
 
 OTIO_API int MapComposableTimeRange_max_size(MapComposableTimeRange *self) {
-    return reinterpret_cast<MapDef *>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<MapDef *>(self)->max_size());
 }
 
 OTIO_API bool MapComposableTimeRange_empty(MapComposableTimeRange *self) {

--- a/src/copentimelineio/marker.cpp
+++ b/src/copentimelineio/marker.cpp
@@ -68,7 +68,7 @@ OTIO_API Marker *Marker_create(
 OTIO_API const char *Marker_color(Marker *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Marker *>(self)->color();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 OTIO_API void Marker_set_color(Marker *self, const char *color) {
     reinterpret_cast<OTIO_NS::Marker *>(self)->set_color(color);

--- a/src/copentimelineio/marker.cpp
+++ b/src/copentimelineio/marker.cpp
@@ -10,7 +10,6 @@
 #include <opentimelineio/marker.h>
 #include <opentimelineio/serializableObject.h>
 #include <opentimelineio/version.h>
-#include <string.h>
 
 typedef OTIO_NS::SerializableObject::Retainer<OTIO_NS::Marker> MarkerRetainer;
 
@@ -68,9 +67,7 @@ OTIO_API Marker *Marker_create(
 OTIO_API const char *Marker_color(Marker *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Marker *>(self)->color();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 OTIO_API void Marker_set_color(Marker *self, const char *color) {
     reinterpret_cast<OTIO_NS::Marker *>(self)->set_color(color);

--- a/src/copentimelineio/marker.cpp
+++ b/src/copentimelineio/marker.cpp
@@ -10,6 +10,7 @@
 #include <opentimelineio/marker.h>
 #include <opentimelineio/serializableObject.h>
 #include <opentimelineio/version.h>
+#include <string.h>
 
 typedef OTIO_NS::SerializableObject::Retainer<OTIO_NS::Marker> MarkerRetainer;
 

--- a/src/copentimelineio/marker.cpp
+++ b/src/copentimelineio/marker.cpp
@@ -67,7 +67,7 @@ OTIO_API Marker *Marker_create(
 OTIO_API const char *Marker_color(Marker *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Marker *>(self)->color();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 OTIO_API void Marker_set_color(Marker *self, const char *color) {
     reinterpret_cast<OTIO_NS::Marker *>(self)->set_color(color);

--- a/src/copentimelineio/markerRetainerVector.cpp
+++ b/src/copentimelineio/markerRetainerVector.cpp
@@ -37,15 +37,15 @@ MarkerRetainerVector_end(MarkerRetainerVector *self) {
 }
 
 OTIO_API int MarkerRetainerVector_size(MarkerRetainerVector *self) {
-    return reinterpret_cast<MarkerRetainerVectorDef *>(self)->size();
+    return static_cast<int>(reinterpret_cast<MarkerRetainerVectorDef *>(self)->size());
 }
 
 OTIO_API int MarkerRetainerVector_max_size(MarkerRetainerVector *self) {
-    return reinterpret_cast<MarkerRetainerVectorDef *>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<MarkerRetainerVectorDef *>(self)->max_size());
 }
 
 OTIO_API int MarkerRetainerVector_capacity(MarkerRetainerVector *self) {
-    return reinterpret_cast<MarkerRetainerVectorDef *>(self)->capacity();
+    return static_cast<int>(reinterpret_cast<MarkerRetainerVectorDef *>(self)->capacity());
 }
 
 OTIO_API void MarkerRetainerVector_resize(MarkerRetainerVector *self, int n) {

--- a/src/copentimelineio/markerVector.cpp
+++ b/src/copentimelineio/markerVector.cpp
@@ -31,15 +31,15 @@ OTIO_API MarkerVectorIterator *MarkerVector_end(MarkerVector *self) {
 }
 
 OTIO_API int MarkerVector_size(MarkerVector *self) {
-    return reinterpret_cast<MarkerVectorDef *>(self)->size();
+    return static_cast<int>(reinterpret_cast<MarkerVectorDef *>(self)->size());
 }
 
 OTIO_API int MarkerVector_max_size(MarkerVector *self) {
-    return reinterpret_cast<MarkerVectorDef *>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<MarkerVectorDef *>(self)->max_size());
 }
 
 OTIO_API int MarkerVector_capacity(MarkerVector *self) {
-    return reinterpret_cast<MarkerVectorDef *>(self)->capacity();
+    return static_cast<int>(reinterpret_cast<MarkerVectorDef *>(self)->capacity());
 }
 
 OTIO_API void MarkerVector_resize(MarkerVector *self, int n) {

--- a/src/copentimelineio/safely_typed_any.cpp
+++ b/src/copentimelineio/safely_typed_any.cpp
@@ -95,7 +95,7 @@ OTIO_API double safely_cast_double_any(Any *a) {
 OTIO_API const char *safely_cast_string_any(Any *a) {
     std::string returnStr = OTIO_NS::safely_cast_string_any(
             *reinterpret_cast<OTIO_NS::any *>(a));
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 OTIO_API RationalTime safely_cast_rational_time_any(Any *a) {
     opentime::RationalTime rationalTime =

--- a/src/copentimelineio/safely_typed_any.cpp
+++ b/src/copentimelineio/safely_typed_any.cpp
@@ -11,6 +11,7 @@
 #include <opentimelineio/safely_typed_any.h>
 #include <opentimelineio/serializableObject.h>
 #include <opentimelineio/version.h>
+#include <string.h>
 #include <utility>
 #include <vector>
 

--- a/src/copentimelineio/safely_typed_any.cpp
+++ b/src/copentimelineio/safely_typed_any.cpp
@@ -11,7 +11,6 @@
 #include <opentimelineio/safely_typed_any.h>
 #include <opentimelineio/serializableObject.h>
 #include <opentimelineio/version.h>
-#include <string.h>
 #include <utility>
 #include <vector>
 
@@ -95,9 +94,7 @@ OTIO_API double safely_cast_double_any(Any *a) {
 OTIO_API const char *safely_cast_string_any(Any *a) {
     std::string returnStr = OTIO_NS::safely_cast_string_any(
             *reinterpret_cast<OTIO_NS::any *>(a));
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 OTIO_API RationalTime safely_cast_rational_time_any(Any *a) {
     opentime::RationalTime rationalTime =

--- a/src/copentimelineio/safely_typed_any.cpp
+++ b/src/copentimelineio/safely_typed_any.cpp
@@ -94,7 +94,7 @@ OTIO_API double safely_cast_double_any(Any *a) {
 OTIO_API const char *safely_cast_string_any(Any *a) {
     std::string returnStr = OTIO_NS::safely_cast_string_any(
             *reinterpret_cast<OTIO_NS::any *>(a));
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 OTIO_API RationalTime safely_cast_rational_time_any(Any *a) {
     opentime::RationalTime rationalTime =

--- a/src/copentimelineio/serializableObject.cpp
+++ b/src/copentimelineio/serializableObject.cpp
@@ -2,8 +2,8 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/serializableObject.h"
+#include "copentime/util.h"
 #include <opentimelineio/serializableObject.h>
-#include <string.h>
 
 typedef OTIO_NS::SerializableObject::Retainer<OTIO_NS::SerializableObject>
     SerializableObjectRetainer;
@@ -66,9 +66,7 @@ SerializableObject_to_json_string(
             ->to_json_string(
                 reinterpret_cast<OTIO_NS::ErrorStatus*>(error_status),
                 indent);
-    char* charPtr = (char*) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 
 OTIO_API OTIOSerializableObject*
@@ -131,9 +129,7 @@ SerializableObject_schema_name(OTIOSerializableObject* self)
 {
     std::string returnStr =
         reinterpret_cast<OTIO_NS::SerializableObject*>(self)->schema_name();
-    char* charPtr = (char*) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 
 OTIO_API int

--- a/src/copentimelineio/serializableObject.cpp
+++ b/src/copentimelineio/serializableObject.cpp
@@ -2,8 +2,8 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/serializableObject.h"
-#include "copentime/util.h"
 #include <opentimelineio/serializableObject.h>
+#include <string.h>
 
 typedef OTIO_NS::SerializableObject::Retainer<OTIO_NS::SerializableObject>
     SerializableObjectRetainer;

--- a/src/copentimelineio/serializableObject.cpp
+++ b/src/copentimelineio/serializableObject.cpp
@@ -66,7 +66,7 @@ SerializableObject_to_json_string(
             ->to_json_string(
                 reinterpret_cast<OTIO_NS::ErrorStatus*>(error_status),
                 indent);
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 
 OTIO_API OTIOSerializableObject*
@@ -129,7 +129,7 @@ SerializableObject_schema_name(OTIOSerializableObject* self)
 {
     std::string returnStr =
         reinterpret_cast<OTIO_NS::SerializableObject*>(self)->schema_name();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 
 OTIO_API int

--- a/src/copentimelineio/serializableObject.cpp
+++ b/src/copentimelineio/serializableObject.cpp
@@ -66,7 +66,7 @@ SerializableObject_to_json_string(
             ->to_json_string(
                 reinterpret_cast<OTIO_NS::ErrorStatus*>(error_status),
                 indent);
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 
 OTIO_API OTIOSerializableObject*
@@ -129,7 +129,7 @@ SerializableObject_schema_name(OTIOSerializableObject* self)
 {
     std::string returnStr =
         reinterpret_cast<OTIO_NS::SerializableObject*>(self)->schema_name();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 
 OTIO_API int

--- a/src/copentimelineio/serializableObjectRetainerVector.cpp
+++ b/src/copentimelineio/serializableObjectRetainerVector.cpp
@@ -43,20 +43,20 @@ SerializableObjectRetainerVector_end(SerializableObjectRetainerVector *self) {
 
 OTIO_API int SerializableObjectRetainerVector_size(
         SerializableObjectRetainerVector *self) {
-    return reinterpret_cast<SerializableObjectRetainerVectorDef *>(self)
-            ->size();
+    return static_cast<int>(
+        reinterpret_cast<SerializableObjectRetainerVectorDef *>(self)->size());
 }
 
 OTIO_API int SerializableObjectRetainerVector_max_size(
         SerializableObjectRetainerVector *self) {
-    return reinterpret_cast<SerializableObjectRetainerVectorDef *>(self)
-            ->max_size();
+    return static_cast<int>(
+        reinterpret_cast<SerializableObjectRetainerVectorDef *>(self)->max_size());
 }
 
 OTIO_API int SerializableObjectRetainerVector_capacity(
         SerializableObjectRetainerVector *self) {
-    return reinterpret_cast<SerializableObjectRetainerVectorDef *>(self)
-            ->capacity();
+    return static_cast<int>(
+        reinterpret_cast<SerializableObjectRetainerVectorDef *>(self)->capacity());
 }
 
 OTIO_API void SerializableObjectRetainerVector_resize(

--- a/src/copentimelineio/serializableObjectVector.cpp
+++ b/src/copentimelineio/serializableObjectVector.cpp
@@ -36,15 +36,15 @@ SerializableObjectVector_end(SerializableObjectVector* self)
 }
 OTIO_API int SerializableObjectVector_size(SerializableObjectVector* self)
 {
-    return reinterpret_cast<SerializableObjectVectorDef*>(self)->size();
+    return static_cast<int>(reinterpret_cast<SerializableObjectVectorDef*>(self)->size());
 }
 OTIO_API int SerializableObjectVector_max_size(SerializableObjectVector* self)
 {
-    return reinterpret_cast<SerializableObjectVectorDef*>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<SerializableObjectVectorDef*>(self)->max_size());
 }
 OTIO_API int SerializableObjectVector_capacity(SerializableObjectVector* self)
 {
-    return reinterpret_cast<SerializableObjectVectorDef*>(self)->capacity();
+    return static_cast<int>(reinterpret_cast<SerializableObjectVectorDef*>(self)->capacity());
 }
 OTIO_API void SerializableObjectVector_resize(SerializableObjectVector* self, int n)
 {

--- a/src/copentimelineio/serializableObjectWithMetadata.cpp
+++ b/src/copentimelineio/serializableObjectWithMetadata.cpp
@@ -2,8 +2,8 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/serializableObjectWithMetadata.h"
+#include "copentime/util.h"
 #include <opentimelineio/serializableObjectWithMetadata.h>
-#include <string.h>
 
 OTIO_API SerializableObjectWithMetadata *SerializableObjectWithMetadata_create(
         const char *name, AnyDictionary *metadata) {
@@ -23,9 +23,7 @@ SerializableObjectWithMetadata_name(SerializableObjectWithMetadata *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::SerializableObjectWithMetadata *>(self)
                     ->name();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 OTIO_API void SerializableObjectWithMetadata_set_name(
         SerializableObjectWithMetadata *self, const char *name) {

--- a/src/copentimelineio/serializableObjectWithMetadata.cpp
+++ b/src/copentimelineio/serializableObjectWithMetadata.cpp
@@ -23,7 +23,7 @@ SerializableObjectWithMetadata_name(SerializableObjectWithMetadata *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::SerializableObjectWithMetadata *>(self)
                     ->name();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 OTIO_API void SerializableObjectWithMetadata_set_name(
         SerializableObjectWithMetadata *self, const char *name) {

--- a/src/copentimelineio/serializableObjectWithMetadata.cpp
+++ b/src/copentimelineio/serializableObjectWithMetadata.cpp
@@ -23,7 +23,7 @@ SerializableObjectWithMetadata_name(SerializableObjectWithMetadata *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::SerializableObjectWithMetadata *>(self)
                     ->name();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 OTIO_API void SerializableObjectWithMetadata_set_name(
         SerializableObjectWithMetadata *self, const char *name) {

--- a/src/copentimelineio/serializableObjectWithMetadata.cpp
+++ b/src/copentimelineio/serializableObjectWithMetadata.cpp
@@ -2,8 +2,8 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/serializableObjectWithMetadata.h"
-#include "copentime/util.h"
 #include <opentimelineio/serializableObjectWithMetadata.h>
+#include <string.h>
 
 OTIO_API SerializableObjectWithMetadata *SerializableObjectWithMetadata_create(
         const char *name, AnyDictionary *metadata) {

--- a/src/copentimelineio/serialization.cpp
+++ b/src/copentimelineio/serialization.cpp
@@ -11,7 +11,7 @@ OTIO_API const char *serialize_json_to_string(
             *reinterpret_cast<OTIO_NS::any *>(value),
             reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status),
             indent);
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 
 OTIO_API bool serialize_json_to_file(

--- a/src/copentimelineio/serialization.cpp
+++ b/src/copentimelineio/serialization.cpp
@@ -11,7 +11,7 @@ OTIO_API const char *serialize_json_to_string(
             *reinterpret_cast<OTIO_NS::any *>(value),
             reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status),
             indent);
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 
 OTIO_API bool serialize_json_to_file(

--- a/src/copentimelineio/serialization.cpp
+++ b/src/copentimelineio/serialization.cpp
@@ -2,8 +2,8 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/serialization.h"
-#include "copentime/util.h"
 #include <opentimelineio/serialization.h>
+#include <string.h>
 
 OTIO_API const char *serialize_json_to_string(
         Any *value, OTIOErrorStatus *error_status, int indent) {

--- a/src/copentimelineio/serialization.cpp
+++ b/src/copentimelineio/serialization.cpp
@@ -2,8 +2,8 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/serialization.h"
+#include "copentime/util.h"
 #include <opentimelineio/serialization.h>
-#include <string.h>
 
 OTIO_API const char *serialize_json_to_string(
         Any *value, OTIOErrorStatus *error_status, int indent) {
@@ -11,9 +11,7 @@ OTIO_API const char *serialize_json_to_string(
             *reinterpret_cast<OTIO_NS::any *>(value),
             reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status),
             indent);
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 
 OTIO_API bool serialize_json_to_file(

--- a/src/copentimelineio/track.cpp
+++ b/src/copentimelineio/track.cpp
@@ -68,7 +68,7 @@ OTIO_API Track *Track_create(
 }
 OTIO_API const char *Track_kind(Track *self) {
     std::string returnStr = reinterpret_cast<OTIO_NS::Track *>(self)->kind();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 OTIO_API void Track_set_kind(Track *self, const char *kind) {
     reinterpret_cast<OTIO_NS::Track *>(self)->set_kind(kind);

--- a/src/copentimelineio/track.cpp
+++ b/src/copentimelineio/track.cpp
@@ -10,8 +10,6 @@
 #include <opentimelineio/composable.h>
 #include <opentimelineio/errorStatus.h>
 #include <opentimelineio/track.h>
-#include <optional>
-#include <string.h>
 #include <utility>
 
 typedef std::map<OTIO_NS::Composable *, opentime::TimeRange>::iterator
@@ -69,9 +67,7 @@ OTIO_API Track *Track_create(
 }
 OTIO_API const char *Track_kind(Track *self) {
     std::string returnStr = reinterpret_cast<OTIO_NS::Track *>(self)->kind();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 OTIO_API void Track_set_kind(Track *self, const char *kind) {
     reinterpret_cast<OTIO_NS::Track *>(self)->set_kind(kind);

--- a/src/copentimelineio/track.cpp
+++ b/src/copentimelineio/track.cpp
@@ -10,6 +10,7 @@
 #include <opentimelineio/composable.h>
 #include <opentimelineio/errorStatus.h>
 #include <opentimelineio/track.h>
+#include <string.h>
 #include <utility>
 
 typedef std::map<OTIO_NS::Composable *, opentime::TimeRange>::iterator

--- a/src/copentimelineio/track.cpp
+++ b/src/copentimelineio/track.cpp
@@ -67,7 +67,7 @@ OTIO_API Track *Track_create(
 }
 OTIO_API const char *Track_kind(Track *self) {
     std::string returnStr = reinterpret_cast<OTIO_NS::Track *>(self)->kind();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 OTIO_API void Track_set_kind(Track *self, const char *kind) {
     reinterpret_cast<OTIO_NS::Track *>(self)->set_kind(kind);

--- a/src/copentimelineio/trackVector.cpp
+++ b/src/copentimelineio/trackVector.cpp
@@ -31,15 +31,15 @@ OTIO_API TrackVectorIterator *TrackVector_end(TrackVector *self) {
 }
 
 OTIO_API int TrackVector_size(TrackVector *self) {
-    return reinterpret_cast<TrackVectorDef *>(self)->size();
+    return static_cast<int>(reinterpret_cast<TrackVectorDef *>(self)->size());
 }
 
 OTIO_API int TrackVector_max_size(TrackVector *self) {
-    return reinterpret_cast<TrackVectorDef *>(self)->max_size();
+    return static_cast<int>(reinterpret_cast<TrackVectorDef *>(self)->max_size());
 }
 
 OTIO_API int TrackVector_capacity(TrackVector *self) {
-    return reinterpret_cast<TrackVectorDef *>(self)->capacity();
+    return static_cast<int>(reinterpret_cast<TrackVectorDef *>(self)->capacity());
 }
 
 OTIO_API void TrackVector_resize(TrackVector *self, int n) {

--- a/src/copentimelineio/transition.cpp
+++ b/src/copentimelineio/transition.cpp
@@ -9,7 +9,6 @@
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/errorStatus.h>
 #include <opentimelineio/transition.h>
-#include <string.h>
 
 
 const char *TransitionType_SMPTE_Dissolve =
@@ -53,9 +52,7 @@ OTIO_API bool Transition_overlapping(Transition *self) {
 OTIO_API const char *Transition_transition_type(Transition *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Transition *>(self)->transition_type();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 OTIO_API void Transition_set_transition_type(
         Transition *self, const char *transition_type) {
@@ -107,9 +104,7 @@ OTIO_API OptionalTimeRange Transition_trimmed_range_in_parent(
 OTIO_API const char *Transition_name(Transition *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Transition *>(self)->name();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 OTIO_API AnyDictionary *Transition_metadata(Transition *self) {
     OTIO_NS::AnyDictionary anyDictionary =

--- a/src/copentimelineio/transition.cpp
+++ b/src/copentimelineio/transition.cpp
@@ -52,7 +52,7 @@ OTIO_API bool Transition_overlapping(Transition *self) {
 OTIO_API const char *Transition_transition_type(Transition *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Transition *>(self)->transition_type();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 OTIO_API void Transition_set_transition_type(
         Transition *self, const char *transition_type) {
@@ -104,7 +104,7 @@ OTIO_API OptionalTimeRange Transition_trimmed_range_in_parent(
 OTIO_API const char *Transition_name(Transition *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Transition *>(self)->name();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 OTIO_API AnyDictionary *Transition_metadata(Transition *self) {
     OTIO_NS::AnyDictionary anyDictionary =

--- a/src/copentimelineio/transition.cpp
+++ b/src/copentimelineio/transition.cpp
@@ -9,7 +9,7 @@
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/errorStatus.h>
 #include <opentimelineio/transition.h>
-
+#include <string.h>
 
 const char *TransitionType_SMPTE_Dissolve =
         OTIO_NS::Transition::Type::SMPTE_Dissolve;

--- a/src/copentimelineio/transition.cpp
+++ b/src/copentimelineio/transition.cpp
@@ -52,7 +52,7 @@ OTIO_API bool Transition_overlapping(Transition *self) {
 OTIO_API const char *Transition_transition_type(Transition *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Transition *>(self)->transition_type();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 OTIO_API void Transition_set_transition_type(
         Transition *self, const char *transition_type) {
@@ -104,7 +104,7 @@ OTIO_API OptionalTimeRange Transition_trimmed_range_in_parent(
 OTIO_API const char *Transition_name(Transition *self) {
     std::string returnStr =
             reinterpret_cast<OTIO_NS::Transition *>(self)->name();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 OTIO_API AnyDictionary *Transition_metadata(Transition *self) {
     OTIO_NS::AnyDictionary anyDictionary =

--- a/src/copentimelineio/unknownSchema.cpp
+++ b/src/copentimelineio/unknownSchema.cpp
@@ -15,7 +15,7 @@ OTIO_API UnknownSchema *UnknownSchema_create(
 OTIO_API const char *UnknownSchema_original_schema_name(UnknownSchema *self) {
     std::string returnStr = reinterpret_cast<OTIO_NS::UnknownSchema *>(self)
             ->original_schema_name();
-    return _strdup(returnStr.c_str());
+    return strdup(returnStr.c_str());
 }
 
 OTIO_API int UnknownSchema_original_schema_version(UnknownSchema *self) {

--- a/src/copentimelineio/unknownSchema.cpp
+++ b/src/copentimelineio/unknownSchema.cpp
@@ -2,9 +2,9 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/unknownSchema.h"
-#include "copentime/util.h"
 #include <copentimelineio/serializableObject.h>
 #include <opentimelineio/unknownSchema.h>
+#include <string.h>
 
 OTIO_API UnknownSchema *UnknownSchema_create(
         const char *original_schema_name, int original_schema_version) {

--- a/src/copentimelineio/unknownSchema.cpp
+++ b/src/copentimelineio/unknownSchema.cpp
@@ -15,7 +15,7 @@ OTIO_API UnknownSchema *UnknownSchema_create(
 OTIO_API const char *UnknownSchema_original_schema_name(UnknownSchema *self) {
     std::string returnStr = reinterpret_cast<OTIO_NS::UnknownSchema *>(self)
             ->original_schema_name();
-    return CppString_to_CString(returnStr);
+    return _strdup(returnStr.c_str());
 }
 
 OTIO_API int UnknownSchema_original_schema_version(UnknownSchema *self) {

--- a/src/copentimelineio/unknownSchema.cpp
+++ b/src/copentimelineio/unknownSchema.cpp
@@ -2,9 +2,9 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/unknownSchema.h"
+#include "copentime/util.h"
 #include <copentimelineio/serializableObject.h>
 #include <opentimelineio/unknownSchema.h>
-#include <string.h>
 
 OTIO_API UnknownSchema *UnknownSchema_create(
         const char *original_schema_name, int original_schema_version) {
@@ -15,9 +15,7 @@ OTIO_API UnknownSchema *UnknownSchema_create(
 OTIO_API const char *UnknownSchema_original_schema_name(UnknownSchema *self) {
     std::string returnStr = reinterpret_cast<OTIO_NS::UnknownSchema *>(self)
             ->original_schema_name();
-    char *charPtr = (char *) malloc((returnStr.size() + 1) * sizeof(char));
-    strcpy(charPtr, returnStr.c_str());
-    return charPtr;
+    return CppString_to_CString(returnStr);
 }
 
 OTIO_API int UnknownSchema_original_schema_version(UnknownSchema *self) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ set(TESTS
     OTIOTrackAlgoTests
 )
 foreach(TEST ${TESTS})
-    add_executable(C${TEST} ${TEST}.c epsilon.h)
+    add_executable(C${TEST} ${TEST}.c epsilon.h util.h util.c)
     target_include_directories(C${TEST} PRIVATE
         "${PROJECT_SOURCE_DIR}/include"
         "${PROJECT_SOURCE_DIR}/OpenTimelineIO/src/deps"

--- a/tests/OTIOCompositionTests.c
+++ b/tests/OTIOCompositionTests.c
@@ -586,8 +586,7 @@ static void otio_stack_range_of_child_with_duration_test(void **state) {
 
     Clip *errorClip = Clip_create(NULL, NULL, nullRange, NULL);
     OTIO_RETAIN(errorClip);
-    OptionalTimeRange errorTime =
-            Item_trimmed_range_in_parent((Item *) errorClip, errorStatus);
+    Item_trimmed_range_in_parent((Item *) errorClip, errorStatus);
     OTIO_ErrorStatus_Outcome outcome = OTIOErrorStatus_get_outcome(errorStatus);
     assert_int_equal(outcome, 18);
     OTIO_RELEASE(errorClip);
@@ -957,8 +956,7 @@ static void otio_track_range_test(void **state) {
             TimeRange_create_with_start_time_and_duration(start_time, duration));
     assert_true(TimeRange_equal(OptionalTimeRange_value(tr), sq_range_child_minus_1));
 
-    TimeRange sq_range_child_minus_error =
-            Track_range_of_child_at_index(sq, 11, errorStatus);
+    Track_range_of_child_at_index(sq, 11, errorStatus);
     OTIO_ErrorStatus_Outcome outcome = OTIOErrorStatus_get_outcome(errorStatus);
     assert_int_equal(outcome, 13);
 
@@ -1496,10 +1494,10 @@ static void otio_track_neighbors_of_simple_test(void **state) {
 static void otio_track_neighbors_of_from_data_test(void **state) {
     const char *sample_data_dir = xstr(SAMPLE_DATA_DIR);
     const char *edl_file = "transition_test.otio";
-    char *edl_path = (char *) calloc(
-            strlen(sample_data_dir) + strlen(edl_file) + 1, sizeof(char));
-    strcpy(edl_path, sample_data_dir);
-    strcat(edl_path, edl_file);
+    const size_t edl_path_size = strlen(sample_data_dir) + strlen(edl_file) + 1;
+    char *edl_path = (char *) calloc(edl_path_size, sizeof(char));
+    strcpy_s(edl_path, edl_path_size, sample_data_dir);
+    strcat_s(edl_path, edl_path_size, edl_file);
 
     OptionalRationalTime nullTime = OptionalRationalTime_create_null();
     Timeline *timeline = Timeline_create(NULL, nullTime, NULL);
@@ -1665,10 +1663,10 @@ static void otio_track_neighbors_of_from_data_test(void **state) {
 static void otio_track_range_of_all_children_test(void **state) {
     const char *sample_data_dir = xstr(SAMPLE_DATA_DIR);
     const char *edl_file = "transition_test.otio";
-    char *edl_path = (char *) calloc(
-            strlen(sample_data_dir) + strlen(edl_file) + 1, sizeof(char));
-    strcpy(edl_path, sample_data_dir);
-    strcat(edl_path, edl_file);
+    const size_t edl_path_size = strlen(sample_data_dir) + strlen(edl_file) + 1;
+    char *edl_path = (char *) calloc(edl_path_size, sizeof(char));
+    strcpy_s(edl_path, edl_path_size, sample_data_dir);
+    strcat_s(edl_path, edl_path_size, edl_file);
 
     OptionalRationalTime nullTime = OptionalRationalTime_create_null();
     Timeline *timeline = Timeline_create(NULL, nullTime, NULL);

--- a/tests/OTIOCompositionTests.c
+++ b/tests/OTIOCompositionTests.c
@@ -1493,11 +1493,13 @@ static void otio_track_neighbors_of_simple_test(void **state) {
 
 static void otio_track_neighbors_of_from_data_test(void **state) {
     const char *sample_data_dir = xstr(SAMPLE_DATA_DIR);
+    const size_t sample_data_dir_size = strlen(sample_data_dir);
     const char *edl_file = "transition_test.otio";
-    const size_t edl_path_size = strlen(sample_data_dir) + strlen(edl_file) + 1;
+    const size_t edl_file_size = strlen(edl_file);
+    const size_t edl_path_size = sample_data_dir_size + edl_file_size + 1;
     char *edl_path = (char *) calloc(edl_path_size, sizeof(char));
-    strcpy_s(edl_path, edl_path_size, sample_data_dir);
-    strcat_s(edl_path, edl_path_size, edl_file);
+    memcpy(edl_path, sample_data_dir, sample_data_dir_size);
+    memcpy(edl_path + sample_data_dir_size, edl_file, edl_file_size);
 
     OptionalRationalTime nullTime = OptionalRationalTime_create_null();
     Timeline *timeline = Timeline_create(NULL, nullTime, NULL);
@@ -1662,11 +1664,13 @@ static void otio_track_neighbors_of_from_data_test(void **state) {
 
 static void otio_track_range_of_all_children_test(void **state) {
     const char *sample_data_dir = xstr(SAMPLE_DATA_DIR);
+    const size_t sample_data_dir_size = strlen(sample_data_dir);
     const char *edl_file = "transition_test.otio";
-    const size_t edl_path_size = strlen(sample_data_dir) + strlen(edl_file) + 1;
+    const size_t edl_file_size = strlen(edl_file);
+    const size_t edl_path_size = sample_data_dir_size + edl_file_size + 1;
     char *edl_path = (char *) calloc(edl_path_size, sizeof(char));
-    strcpy_s(edl_path, edl_path_size, sample_data_dir);
-    strcat_s(edl_path, edl_path_size, edl_file);
+    memcpy(edl_path, sample_data_dir, sample_data_dir_size);
+    memcpy(edl_path + sample_data_dir_size, edl_file, edl_file_size);
 
     OptionalRationalTime nullTime = OptionalRationalTime_create_null();
     Timeline *timeline = Timeline_create(NULL, nullTime, NULL);

--- a/tests/OTIOCompositionTests.c
+++ b/tests/OTIOCompositionTests.c
@@ -1496,8 +1496,9 @@ static void otio_track_neighbors_of_from_data_test(void **state) {
     const size_t sample_data_dir_size = strlen(sample_data_dir);
     const char *edl_file = "transition_test.otio";
     const size_t edl_file_size = strlen(edl_file);
-    const size_t edl_path_size = sample_data_dir_size + edl_file_size + 1;
-    char *edl_path = (char *) calloc(edl_path_size, sizeof(char));
+    char *edl_path = (char *) calloc(
+        sample_data_dir_size + edl_file_size + 1,
+        sizeof(char));
     memcpy(edl_path, sample_data_dir, sample_data_dir_size);
     memcpy(edl_path + sample_data_dir_size, edl_file, edl_file_size);
 
@@ -1667,8 +1668,9 @@ static void otio_track_range_of_all_children_test(void **state) {
     const size_t sample_data_dir_size = strlen(sample_data_dir);
     const char *edl_file = "transition_test.otio";
     const size_t edl_file_size = strlen(edl_file);
-    const size_t edl_path_size = sample_data_dir_size + edl_file_size + 1;
-    char *edl_path = (char *) calloc(edl_path_size, sizeof(char));
+    char *edl_path = (char *) calloc(
+        sample_data_dir_size + edl_file_size + 1,
+        sizeof(char));
     memcpy(edl_path, sample_data_dir, sample_data_dir_size);
     memcpy(edl_path + sample_data_dir_size, edl_file, edl_file_size);
 

--- a/tests/OTIOCompositionTests.c
+++ b/tests/OTIOCompositionTests.c
@@ -1496,11 +1496,11 @@ static void otio_track_neighbors_of_from_data_test(void **state) {
     const size_t sample_data_dir_size = strlen(sample_data_dir);
     const char *edl_file = "transition_test.otio";
     const size_t edl_file_size = strlen(edl_file);
-    char *edl_path = (char *) calloc(
-        sample_data_dir_size + edl_file_size + 1,
-        sizeof(char));
+    const size_t edl_path_size = sample_data_dir_size + edl_file_size;
+    char *edl_path = (char *) calloc(edl_path_size + 1, sizeof(char));
     memcpy(edl_path, sample_data_dir, sample_data_dir_size);
     memcpy(edl_path + sample_data_dir_size, edl_file, edl_file_size);
+    edl_path[edl_path_size] = 0;
 
     OptionalRationalTime nullTime = OptionalRationalTime_create_null();
     Timeline *timeline = Timeline_create(NULL, nullTime, NULL);
@@ -1668,11 +1668,11 @@ static void otio_track_range_of_all_children_test(void **state) {
     const size_t sample_data_dir_size = strlen(sample_data_dir);
     const char *edl_file = "transition_test.otio";
     const size_t edl_file_size = strlen(edl_file);
-    char *edl_path = (char *) calloc(
-        sample_data_dir_size + edl_file_size + 1,
-        sizeof(char));
+    const size_t edl_path_size = sample_data_dir_size + edl_file_size;
+    char *edl_path = (char *) calloc(edl_path_size + 1, sizeof(char));
     memcpy(edl_path, sample_data_dir, sample_data_dir_size);
     memcpy(edl_path + sample_data_dir_size, edl_file, edl_file_size);
+    edl_path[edl_path_size] = 0;
 
     OptionalRationalTime nullTime = OptionalRationalTime_create_null();
     Timeline *timeline = Timeline_create(NULL, nullTime, NULL);

--- a/tests/OTIOCompositionTests.c
+++ b/tests/OTIOCompositionTests.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenTimelineIO project
 
+#include "util.h"
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -1493,14 +1495,8 @@ static void otio_track_neighbors_of_simple_test(void **state) {
 
 static void otio_track_neighbors_of_from_data_test(void **state) {
     const char *sample_data_dir = xstr(SAMPLE_DATA_DIR);
-    const size_t sample_data_dir_size = strlen(sample_data_dir);
     const char *edl_file = "transition_test.otio";
-    const size_t edl_file_size = strlen(edl_file);
-    const size_t edl_path_size = sample_data_dir_size + edl_file_size;
-    char *edl_path = (char *) calloc(edl_path_size + 1, sizeof(char));
-    memcpy(edl_path, sample_data_dir, sample_data_dir_size);
-    memcpy(edl_path + sample_data_dir_size, edl_file, edl_file_size);
-    edl_path[edl_path_size] = 0;
+    char* edl_path = append_path_and_filename(sample_data_dir, edl_file);
 
     OptionalRationalTime nullTime = OptionalRationalTime_create_null();
     Timeline *timeline = Timeline_create(NULL, nullTime, NULL);
@@ -1665,14 +1661,8 @@ static void otio_track_neighbors_of_from_data_test(void **state) {
 
 static void otio_track_range_of_all_children_test(void **state) {
     const char *sample_data_dir = xstr(SAMPLE_DATA_DIR);
-    const size_t sample_data_dir_size = strlen(sample_data_dir);
     const char *edl_file = "transition_test.otio";
-    const size_t edl_file_size = strlen(edl_file);
-    const size_t edl_path_size = sample_data_dir_size + edl_file_size;
-    char *edl_path = (char *) calloc(edl_path_size + 1, sizeof(char));
-    memcpy(edl_path, sample_data_dir, sample_data_dir_size);
-    memcpy(edl_path + sample_data_dir_size, edl_file, edl_file_size);
-    edl_path[edl_path_size] = 0;
+    char* edl_path = append_path_and_filename(sample_data_dir, edl_file);
 
     OptionalRationalTime nullTime = OptionalRationalTime_create_null();
     Timeline *timeline = Timeline_create(NULL, nullTime, NULL);

--- a/tests/OTIOGeneratorReferenceTests.c
+++ b/tests/OTIOGeneratorReferenceTests.c
@@ -189,11 +189,11 @@ static void otio_generator_reference_read_file_test(void **state) {
 
     const char *ref_file = "generator_reference_test.otio";
     const size_t ref_file_size = strlen(ref_file);
-    char *ref_path = (char *) calloc(
-        sample_data_dir_size + ref_file_size + 1,
-        sizeof(char));
+    const size_t ref_path_size = sample_data_dir_size + ref_file_size;
+    char *ref_path = (char *) calloc(ref_path_size + 1, sizeof(char));
     memcpy(ref_path, sample_data_dir, sample_data_dir_size);
     memcpy(ref_path + sample_data_dir_size, ref_file, ref_file_size);
+    ref_path[ref_path_size] = 0;
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 

--- a/tests/OTIOGeneratorReferenceTests.c
+++ b/tests/OTIOGeneratorReferenceTests.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenTimelineIO project
 
+#include "util.h"
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -185,15 +187,9 @@ static void otio_generator_reference_read_file_test(void **state) {
     GeneratorReference *gen = testState->gen;
     RetainerSerializableObject *gen_r = testState->gen_r;
     const char *sample_data_dir = testState->sample_data_dir;
-    const size_t sample_data_dir_size = strlen(sample_data_dir);
 
     const char *ref_file = "generator_reference_test.otio";
-    const size_t ref_file_size = strlen(ref_file);
-    const size_t ref_path_size = sample_data_dir_size + ref_file_size;
-    char *ref_path = (char *) calloc(ref_path_size + 1, sizeof(char));
-    memcpy(ref_path, sample_data_dir, sample_data_dir_size);
-    memcpy(ref_path + sample_data_dir_size, ref_file, ref_file_size);
-    ref_path[ref_path_size] = 0;
+    char* ref_path = append_path_and_filename(sample_data_dir, ref_file);
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 

--- a/tests/OTIOGeneratorReferenceTests.c
+++ b/tests/OTIOGeneratorReferenceTests.c
@@ -185,12 +185,15 @@ static void otio_generator_reference_read_file_test(void **state) {
     GeneratorReference *gen = testState->gen;
     RetainerSerializableObject *gen_r = testState->gen_r;
     const char *sample_data_dir = testState->sample_data_dir;
+    const size_t sample_data_dir_size = strlen(sample_data_dir);
 
     const char *ref_file = "generator_reference_test.otio";
-    const size_t ref_path_size = strlen(sample_data_dir) + strlen(ref_file) + 1;
-    char *ref_path = (char *) calloc(ref_path_size, sizeof(char));
-    strcpy_s(ref_path, ref_path_size, sample_data_dir);
-    strcat_s(ref_path, ref_path_size, ref_file);
+    const size_t ref_file_size = strlen(ref_file);
+    char *ref_path = (char *) calloc(
+        sample_data_dir_size + ref_file_size + 1,
+        sizeof(char));
+    memcpy(ref_path, sample_data_dir, sample_data_dir_size);
+    memcpy(ref_path + sample_data_dir_size, ref_file, ref_file_size);
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 

--- a/tests/OTIOGeneratorReferenceTests.c
+++ b/tests/OTIOGeneratorReferenceTests.c
@@ -187,10 +187,10 @@ static void otio_generator_reference_read_file_test(void **state) {
     const char *sample_data_dir = testState->sample_data_dir;
 
     const char *ref_file = "generator_reference_test.otio";
-    char *ref_path = (char *) calloc(
-            strlen(sample_data_dir) + strlen(ref_file) + 1, sizeof(char));
-    strcpy(ref_path, sample_data_dir);
-    strcat(ref_path, ref_file);
+    const size_t ref_path_size = strlen(sample_data_dir) + strlen(ref_file) + 1;
+    char *ref_path = (char *) calloc(ref_path_size, sizeof(char));
+    strcpy_s(ref_path, ref_path_size, sample_data_dir);
+    strcat_s(ref_path, ref_path_size, ref_file);
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 

--- a/tests/OTIOItemTests.c
+++ b/tests/OTIOItemTests.c
@@ -165,7 +165,7 @@ static void otio_item_copy_available_range_test(void **state) {
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 
-    TimeRange available_range = Item_available_range(it, errorStatus);
+    Item_available_range(it, errorStatus);
 
     assert_int_equal(OTIOErrorStatus_get_outcome(errorStatus), 1);
 
@@ -182,7 +182,7 @@ static void otio_item_copy_duration_and_source_range_test(void **state) {
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 
-    RationalTime it_duration = Item_duration(it, errorStatus);
+    Item_duration(it, errorStatus);
 
     assert_int_equal(OTIOErrorStatus_get_outcome(errorStatus), 1);
 
@@ -217,7 +217,7 @@ static void otio_item_copy_trimmed_range_test(void **state) {
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 
-    TimeRange it_trimmed_range = Item_trimmed_range(it, errorStatus);
+    Item_trimmed_range(it, errorStatus);
 
     assert_int_equal(OTIOErrorStatus_get_outcome(errorStatus), 1);
 

--- a/tests/OTIOStackAlgoTests.c
+++ b/tests/OTIOStackAlgoTests.c
@@ -929,25 +929,25 @@ static void otio_stack_algo_flatten_example_code_test(void **state) {
 
     const char *multitrack_file = "multitrack.otio";
     const size_t multitrack_file_size = strlen(multitrack_file);
-    char *multitrack_path = (char *) calloc(
-        sample_data_dir_size + multitrack_file_size + 1,
-        sizeof(char));
+    const size_t mulitrack_path_size = sample_data_dir_size + multitrack_file_size;
+    char *multitrack_path = (char *) calloc(mulitrack_path_size + 1, sizeof(char));
     memcpy(multitrack_path, sample_data_dir, sample_data_dir_size);
     memcpy(
         multitrack_path + sample_data_dir_size,
         multitrack_file,
         multitrack_file_size);
+    multitrack_path[mulitrack_path_size] = 0;
 
     const char *preflattened_file = "preflattened.otio";
     const size_t preflattened_file_size = strlen(preflattened_file);
-    char *preflattened_path = (char *) calloc(
-        sample_data_dir_size + preflattened_file_size + 1,
-        sizeof(char));
+    const size_t preflattened_path_size = sample_data_dir_size + preflattened_file_size;
+    char *preflattened_path = (char *) calloc(preflattened_path_size + 1, sizeof(char));
     memcpy(preflattened_path, sample_data_dir, sample_data_dir_size);
     memcpy(
         preflattened_path + sample_data_dir_size,
         preflattened_file,
         preflattened_file_size);
+    preflattened_path[preflattened_path_size] = 0;
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 

--- a/tests/OTIOStackAlgoTests.c
+++ b/tests/OTIOStackAlgoTests.c
@@ -927,16 +927,18 @@ static void otio_stack_algo_flatten_example_code_test(void **state) {
     const char *trackgFgStr = testState->trackgFgStr;
 
     const char *multitrack_file = "multitrack.otio";
-    char *multitrack_path = (char *) calloc(
-            strlen(sample_data_dir) + strlen(multitrack_file) + 1, sizeof(char));
-    strcpy(multitrack_path, sample_data_dir);
-    strcat(multitrack_path, multitrack_file);
+    const size_t multitrack_path_size =
+        strlen(sample_data_dir) + strlen(multitrack_file) + 1;
+    char *multitrack_path = (char *) calloc(multitrack_path_size, sizeof(char));
+    strcpy_s(multitrack_path, multitrack_path_size, sample_data_dir);
+    strcat_s(multitrack_path, multitrack_path_size, multitrack_file);
 
     const char *preflattened_file = "preflattened.otio";
-    char *preflattened_path = (char *) calloc(
-            strlen(sample_data_dir) + strlen(multitrack_file) + 1, sizeof(char));
-    strcpy(preflattened_path, sample_data_dir);
-    strcat(preflattened_path, preflattened_file);
+    const size_t preflattened_path_size =
+        strlen(sample_data_dir) + strlen(multitrack_file) + 1;
+    char *preflattened_path = (char *) calloc(preflattened_path_size, sizeof(char));
+    strcpy_s(preflattened_path, preflattened_path_size, sample_data_dir);
+    strcat_s(preflattened_path, preflattened_path_size, preflattened_file);
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 

--- a/tests/OTIOStackAlgoTests.c
+++ b/tests/OTIOStackAlgoTests.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenTimelineIO project
 
+#include "util.h"
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -913,7 +915,6 @@ static void otio_stack_algo_flatten_vector_of_tracks_test(void **state) {
 static void otio_stack_algo_flatten_example_code_test(void **state) {
     struct StackAlgoTestState *testState = *state;
     const char *sample_data_dir = testState->sample_data_dir;
-    const size_t sample_data_dir_size = strlen(sample_data_dir);
     Track *trackZ = testState->trackZ;
     Track *trackABC = testState->trackABC;
     Track *trackDgE = testState->trackDgE;
@@ -928,26 +929,10 @@ static void otio_stack_algo_flatten_example_code_test(void **state) {
     const char *trackgFgStr = testState->trackgFgStr;
 
     const char *multitrack_file = "multitrack.otio";
-    const size_t multitrack_file_size = strlen(multitrack_file);
-    const size_t mulitrack_path_size = sample_data_dir_size + multitrack_file_size;
-    char *multitrack_path = (char *) calloc(mulitrack_path_size + 1, sizeof(char));
-    memcpy(multitrack_path, sample_data_dir, sample_data_dir_size);
-    memcpy(
-        multitrack_path + sample_data_dir_size,
-        multitrack_file,
-        multitrack_file_size);
-    multitrack_path[mulitrack_path_size] = 0;
+    char* multitrack_path = append_path_and_filename(sample_data_dir, multitrack_file);
 
     const char *preflattened_file = "preflattened.otio";
-    const size_t preflattened_file_size = strlen(preflattened_file);
-    const size_t preflattened_path_size = sample_data_dir_size + preflattened_file_size;
-    char *preflattened_path = (char *) calloc(preflattened_path_size + 1, sizeof(char));
-    memcpy(preflattened_path, sample_data_dir, sample_data_dir_size);
-    memcpy(
-        preflattened_path + sample_data_dir_size,
-        preflattened_file,
-        preflattened_file_size);
-    preflattened_path[preflattened_path_size] = 0;
+    char* preflattened_path = append_path_and_filename(sample_data_dir, preflattened_file);
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 

--- a/tests/OTIOStackAlgoTests.c
+++ b/tests/OTIOStackAlgoTests.c
@@ -913,6 +913,7 @@ static void otio_stack_algo_flatten_vector_of_tracks_test(void **state) {
 static void otio_stack_algo_flatten_example_code_test(void **state) {
     struct StackAlgoTestState *testState = *state;
     const char *sample_data_dir = testState->sample_data_dir;
+    const size_t sample_data_dir_size = strlen(sample_data_dir);
     Track *trackZ = testState->trackZ;
     Track *trackABC = testState->trackABC;
     Track *trackDgE = testState->trackDgE;
@@ -927,18 +928,26 @@ static void otio_stack_algo_flatten_example_code_test(void **state) {
     const char *trackgFgStr = testState->trackgFgStr;
 
     const char *multitrack_file = "multitrack.otio";
-    const size_t multitrack_path_size =
-        strlen(sample_data_dir) + strlen(multitrack_file) + 1;
-    char *multitrack_path = (char *) calloc(multitrack_path_size, sizeof(char));
-    strcpy_s(multitrack_path, multitrack_path_size, sample_data_dir);
-    strcat_s(multitrack_path, multitrack_path_size, multitrack_file);
+    const size_t multitrack_file_size = strlen(multitrack_file);
+    char *multitrack_path = (char *) calloc(
+        sample_data_dir_size + multitrack_file_size + 1,
+        sizeof(char));
+    memcpy(multitrack_path, sample_data_dir, sample_data_dir_size);
+    memcpy(
+        multitrack_path + sample_data_dir_size,
+        multitrack_file,
+        multitrack_file_size);
 
     const char *preflattened_file = "preflattened.otio";
-    const size_t preflattened_path_size =
-        strlen(sample_data_dir) + strlen(multitrack_file) + 1;
-    char *preflattened_path = (char *) calloc(preflattened_path_size, sizeof(char));
-    strcpy_s(preflattened_path, preflattened_path_size, sample_data_dir);
-    strcat_s(preflattened_path, preflattened_path_size, preflattened_file);
+    const size_t preflattened_file_size = strlen(preflattened_file);
+    char *preflattened_path = (char *) calloc(
+        sample_data_dir_size + preflattened_file_size + 1,
+        sizeof(char));
+    memcpy(preflattened_path, sample_data_dir, sample_data_dir_size);
+    memcpy(
+        preflattened_path + sample_data_dir_size,
+        preflattened_file,
+        preflattened_file_size);
 
     OTIOErrorStatus *errorStatus = OTIOErrorStatus_create();
 

--- a/tests/util.c
+++ b/tests/util.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+#include "util.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+char* append_path_and_filename(const char* path, const char* filename)
+{
+    const size_t path_size = strlen(path);
+    const size_t filename_size = strlen(filename);
+    const size_t size = path_size + filename_size;
+    char *return_str = (char *) calloc(size + 1, sizeof(char));
+    memcpy(return_str, path, path_size);
+    memcpy(return_str + path_size, filename, filename_size);
+    return_str[size] = 0;
+    return return_str;
+}

--- a/tests/util.h
+++ b/tests/util.h
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+#pragma once
+
+char* append_path_and_filename(const char* path, const char* filename);


### PR DESCRIPTION
Hi, when I was compiling on Windows yesterday I noticed a few warnings, here are some possible fixes:

warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead.
* For copentime and copentimelineio I replaced the calls to ```strcpy``` with a utility function that uses ```memcpy``` (apparently ```strcpy_s``` is only available on Windows).
* For the tests I added a separate utility function that also uses ```memcpy```.

warning C4267: 'return': conversion from 'size_t' to 'int', possible loss of data
* Fixed with ```static_cast```.

warning C4099: 'UnknownSchema': type name first seen using 'struct' now seen using 'class'
* Fixed typedef.

warning STL4038: The contents of <optional> are available only with C++17 or later.
* Fixed by removing include which wasn't being used.

warning C4101: 'available_range': unreferenced local variable
* Fixed by removing unused variables.