### PR TITLE
Cxx17 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 *.pyc
 build*
+compile_commands.json
 cmake-build*
 dist*
 *.egg-info

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "OpenTimelineIO"]
 	path = OpenTimelineIO
-	url = https://github.com/PixarAnimationStudios/OpenTimelineIO
+	url = https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git
 [submodule "cmocka"]
 	path = cmocka
 	url = https://git.cryptomilk.org/projects/cmocka.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "OpenTimelineIO"]
-	path = OpenTimelineIO
-	url = https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git
 [submodule "cmocka"]
 	path = cmocka
 	url = https://git.cryptomilk.org/projects/cmocka.git
+[submodule "OpenTimelineIO"]
+	path = OpenTimelineIO
+	url = https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 #------------------------------------------------------------------------------
 # Global language settings
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ some essential features and there are large changes planned. During this phase
 we actively encourage you to provide feedback, requests, comments, and/or
 contributions.
 
+NOTE: One of these missing features is support for the downgrade versioning
+map in the JSON serialization and deserialization. This can be addressed in
+the future, but for now an empty map is passed to the underlying C++ calls.
+
 Overview
 --------
 

--- a/include/copentimelineio/anyVector.h
+++ b/include/copentimelineio/anyVector.h
@@ -73,9 +73,9 @@ AnyVectorIterator_not_equal(AnyVectorIterator *lhs, AnyVectorIterator *rhs);
 
 OTIO_API void AnyVectorIterator_destroy(AnyVectorIterator *self);
 
-OTIO_API AnyVectorMutationStamp *MutationStamp_create(AnyVector *v);
+OTIO_API AnyVectorMutationStamp *AnyVectorMutationStamp_create(AnyVector *v);
 
-OTIO_API void MutationStamp_destroy(AnyVectorMutationStamp *self);
+OTIO_API void AnyVectorMutationStamp_destroy(AnyVectorMutationStamp *self);
 
 OTIO_API AnyVectorMutationStamp *
 AnyVector_get_or_create_mutation_stamp(AnyVector *self);

--- a/include/copentimelineio/timeline.h
+++ b/include/copentimelineio/timeline.h
@@ -45,6 +45,5 @@ OTIO_API const char *Timeline_to_json_string(
         Timeline *self, OTIOErrorStatus *error_status, int indent);
 OTIO_API bool Timeline_is_equivalent_to(Timeline *self, OTIOSerializableObject *other);
 OTIO_API Timeline *Timeline_clone(Timeline *self, OTIOErrorStatus *error_status);
-OTIO_API bool Timeline_is_unknown_schema(Timeline *self);
 OTIO_API const char *Timeline_schema_name(Timeline *self);
 OTIO_API int Timeline_schema_version(Timeline *self);

--- a/src/copentimelineio/any.cpp
+++ b/src/copentimelineio/any.cpp
@@ -2,7 +2,6 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/any.h"
-//#include <opentimelineio/any.h>
 #include <opentimelineio/version.h>
 #include <any>
 

--- a/src/copentimelineio/any.cpp
+++ b/src/copentimelineio/any.cpp
@@ -2,9 +2,10 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "copentimelineio/any.h"
-#include <opentimelineio/any.h>
+//#include <opentimelineio/any.h>
 #include <opentimelineio/version.h>
+#include <any>
 
 OTIO_API void Any_destroy(Any *self) {
-    delete reinterpret_cast<OTIO_NS::any *>(self);
+    delete reinterpret_cast<std::any *>(self);
 }

--- a/src/copentimelineio/anyDictionary.cpp
+++ b/src/copentimelineio/anyDictionary.cpp
@@ -5,8 +5,9 @@
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/version.h>
 #include <string.h>
+#include <any>
 
-typedef std::map<std::string, OTIO_NS::any>::iterator DictionaryIterator;
+typedef std::map<std::string, std::any>::iterator DictionaryIterator;
 
 OTIO_API AnyDictionary* AnyDictionary_create()
 {
@@ -85,7 +86,7 @@ AnyDictionary_insert(AnyDictionary* self, const char* key, Any* anyObj)
 {
     DictionaryIterator it =
         reinterpret_cast<OTIO_NS::AnyDictionary*>(self)
-            ->insert({ key, *reinterpret_cast<OTIO_NS::any*>(anyObj) })
+            ->insert({ key, *reinterpret_cast<std::any*>(anyObj) })
             .first;
     return reinterpret_cast<AnyDictionaryIterator*>(
         new DictionaryIterator(it));
@@ -118,9 +119,9 @@ OTIO_API const char* AnyDictionaryIterator_key(AnyDictionaryIterator* iter)
 }
 OTIO_API Any* AnyDictionaryIterator_value(AnyDictionaryIterator* iter)
 {
-    OTIO_NS::any value =
+    std::any value =
         (*reinterpret_cast<DictionaryIterator*>(iter))->second;
-    return reinterpret_cast<Any*>(new OTIO_NS::any(value));
+    return reinterpret_cast<Any*>(new std::any(value));
 }
 OTIO_API bool AnyDictionaryIterator_equal(
     AnyDictionaryIterator* lhs, AnyDictionaryIterator* rhs)

--- a/src/copentimelineio/anyVector.cpp
+++ b/src/copentimelineio/anyVector.cpp
@@ -4,8 +4,9 @@
 #include "copentimelineio/anyVector.h"
 #include <opentimelineio/anyVector.h>
 #include <opentimelineio/version.h>
+#include <any>
 
-typedef std::vector<OTIO_NS::any>::iterator VectorIterator;
+typedef std::vector<std::any>::iterator VectorIterator;
 
 OTIO_API AnyVector *AnyVector_create() {
     return reinterpret_cast<AnyVector *>(new OTIO_NS::AnyVector());
@@ -59,14 +60,14 @@ OTIO_API void AnyVector_swap(AnyVector *self, AnyVector *other) {
 }
 
 OTIO_API Any *AnyVector_at(AnyVector *self, int pos) {
-    OTIO_NS::any value =
+    std::any value =
             reinterpret_cast<OTIO_NS::AnyVector *>(self)->at(pos);
-    return reinterpret_cast<Any *>(new OTIO_NS::any(value));
+    return reinterpret_cast<Any *>(new std::any(value));
 }
 
 OTIO_API void AnyVector_push_back(AnyVector *self, Any *value) {
     reinterpret_cast<OTIO_NS::AnyVector *>(self)->push_back(
-            *reinterpret_cast<OTIO_NS::any *>(value));
+            *reinterpret_cast<std::any *>(value));
 }
 
 OTIO_API void AnyVector_pop_back(AnyVector *self) {
@@ -77,7 +78,7 @@ OTIO_API AnyVectorIterator *
 AnyVector_insert(AnyVector *self, AnyVectorIterator *pos, Any *val) {
     VectorIterator it = reinterpret_cast<OTIO_NS::AnyVector *>(self)->insert(
             *reinterpret_cast<VectorIterator *>(pos),
-            *reinterpret_cast<OTIO_NS::any *>(val));
+            *reinterpret_cast<std::any *>(val));
     return reinterpret_cast<AnyVectorIterator *>(new VectorIterator(it));
 }
 
@@ -116,8 +117,8 @@ OTIO_API AnyVectorIterator *AnyVectorIterator_prev(AnyVectorIterator *iter, int 
 }
 
 OTIO_API Any *AnyVectorIterator_value(AnyVectorIterator *iter) {
-    OTIO_NS::any value = *reinterpret_cast<VectorIterator *>(iter);
-    return reinterpret_cast<Any *>(new OTIO_NS::any(value));
+    std::any value = *reinterpret_cast<VectorIterator *>(iter);
+    return reinterpret_cast<Any *>(new std::any(value));
 }
 
 OTIO_API bool

--- a/src/copentimelineio/clip.cpp
+++ b/src/copentimelineio/clip.cpp
@@ -11,6 +11,7 @@
 #include <opentimelineio/clip.h>
 #include <opentimelineio/errorStatus.h>
 #include <opentimelineio/mediaReference.h>
+#include <optional>
 
 OTIO_API Clip *
 Clip_create(
@@ -18,9 +19,9 @@ Clip_create(
         MediaReference *media_reference,
         OptionalTimeRange source_range,
         AnyDictionary *metadata) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional = nonstd::nullopt;
+    std::optional<opentime::TimeRange> timeRangeOptional = std::nullopt;
     if (source_range.valid)
-        timeRangeOptional = nonstd::optional<opentime::TimeRange>(
+        timeRangeOptional = std::optional<opentime::TimeRange>(
                 CTimeRange_to_CppTimeRange(source_range.value));
 
     std::string name_str = std::string();

--- a/src/copentimelineio/composition.cpp
+++ b/src/copentimelineio/composition.cpp
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <utility>
 #include <vector>
+#include <optional>
 
 typedef std::vector<OTIO_NS::Marker *> MarkerVectorDef;
 typedef std::vector<OTIO_NS::Marker *>::iterator MarkerVectorIteratorDef;
@@ -33,8 +34,8 @@ typedef OTIO_NS::SerializableObject::Retainer<OTIO_NS::Composable>
 typedef std::vector<OTIO_NS::Composable *> ComposableVectorDef;
 typedef std::vector<OTIO_NS::Composable *>::iterator ComposableVectorIteratorDef;
 typedef std::pair<
-        nonstd::optional<opentime::RationalTime>,
-        nonstd::optional<opentime::RationalTime>>
+        std::optional<opentime::RationalTime>,
+        std::optional<opentime::RationalTime>>
         PairDef;
 
 OTIO_API Composition *Composition_create(
@@ -43,9 +44,9 @@ OTIO_API Composition *Composition_create(
         AnyDictionary *metadata,
         EffectVector *effects,
         MarkerVector *markers) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional = nonstd::nullopt;
+    std::optional<opentime::TimeRange> timeRangeOptional = std::nullopt;
     if (source_range.valid)
-        timeRangeOptional = nonstd::optional<opentime::TimeRange>(
+        timeRangeOptional = std::optional<opentime::TimeRange>(
                 CTimeRange_to_CppTimeRange(source_range.value));
 
     std::string name_str = std::string();
@@ -166,20 +167,20 @@ OTIO_API OptionalTimeRange Composition_trimmed_range_of_child(
         Composition *self,
         Composable *child,
         OTIOErrorStatus *error_status) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional =
+    std::optional<opentime::TimeRange> timeRangeOptional =
             reinterpret_cast<OTIO_NS::Composition *>(self)
                     ->trimmed_range_of_child(
                             reinterpret_cast<OTIO_NS::Composable *>(child),
                             reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status));
-    if (timeRangeOptional == nonstd::nullopt) return OptionalTimeRange_create_null();
+    if (timeRangeOptional == std::nullopt) return OptionalTimeRange_create_null();
     return OptionalTimeRange_create(CppTimeRange_to_CTimeRange(timeRangeOptional.value()));
 }
 OTIO_API OptionalTimeRange
 Composition_trim_child_range(Composition *self, TimeRange child_range) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional =
+    std::optional<opentime::TimeRange> timeRangeOptional =
             reinterpret_cast<OTIO_NS::Composition *>(self)->trim_child_range(
                     CTimeRange_to_CppTimeRange(child_range));
-    if (timeRangeOptional == nonstd::nullopt) return OptionalTimeRange_create_null();
+    if (timeRangeOptional == std::nullopt) return OptionalTimeRange_create_null();
     return OptionalTimeRange_create(CppTimeRange_to_CTimeRange(timeRangeOptional.value()));
 }
 OTIO_API bool Composition_has_child(Composition *self, Composable *child) {

--- a/src/copentimelineio/deserialization.cpp
+++ b/src/copentimelineio/deserialization.cpp
@@ -3,13 +3,14 @@
 
 #include "copentimelineio/deserialization.h"
 #include <opentimelineio/deserialization.h>
+#include <any>
 
 OTIO_API bool deserialize_json_from_string(
         const char *input, Any *destination, OTIOErrorStatus *error_status) {
     std::string str = input;
     return OTIO_NS::deserialize_json_from_string(
             str,
-            reinterpret_cast<OTIO_NS::any *>(destination),
+            reinterpret_cast<std::any *>(destination),
             reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status));
 }
 
@@ -17,6 +18,6 @@ OTIO_API bool deserialize_json_from_file(
         const char *file_name, Any *destination, OTIOErrorStatus *error_status) {
     return OTIO_NS::deserialize_json_from_file(
             file_name,
-            reinterpret_cast<OTIO_NS::any *>(destination),
+            reinterpret_cast<std::any *>(destination),
             reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status));
 }

--- a/src/copentimelineio/externalReference.cpp
+++ b/src/copentimelineio/externalReference.cpp
@@ -10,14 +10,15 @@
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/externalReference.h>
 #include <string.h>
+#include <optional>
 
 OTIO_API ExternalReference *ExternalReference_create(
         const char *target_url,
         OptionalTimeRange available_range,
         AnyDictionary *metadata) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional = nonstd::nullopt;
+    std::optional<opentime::TimeRange> timeRangeOptional = std::nullopt;
     if (available_range.valid)
-        timeRangeOptional = nonstd::optional<opentime::TimeRange>(
+        timeRangeOptional = std::optional<opentime::TimeRange>(
                 CTimeRange_to_CppTimeRange(available_range.value));
 
     OTIO_NS::AnyDictionary metadataDictionary = OTIO_NS::AnyDictionary();

--- a/src/copentimelineio/generatorReference.cpp
+++ b/src/copentimelineio/generatorReference.cpp
@@ -9,6 +9,7 @@
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/generatorReference.h>
 #include <string.h>
+#include <optional>
 
 OTIO_API GeneratorReference *GeneratorReference_create(
         const char *name,
@@ -32,9 +33,9 @@ OTIO_API GeneratorReference *GeneratorReference_create(
         metadataDictionary =
                 *reinterpret_cast<OTIO_NS::AnyDictionary *>(metadata);
 
-    nonstd::optional<opentime::TimeRange> timeRangeOptional = nonstd::nullopt;
+    std::optional<opentime::TimeRange> timeRangeOptional = std::nullopt;
     if (available_range.valid)
-        timeRangeOptional = nonstd::optional<opentime::TimeRange>(
+        timeRangeOptional = std::optional<opentime::TimeRange>(
                 CTimeRange_to_CppTimeRange(available_range.value));
     return reinterpret_cast<GeneratorReference *>(
             new OTIO_NS::GeneratorReference(

--- a/src/copentimelineio/item.cpp
+++ b/src/copentimelineio/item.cpp
@@ -8,6 +8,7 @@
 #include <opentimelineio/item.h>
 #include <opentimelineio/marker.h>
 #include <opentimelineio/serializableObject.h>
+#include <optional>
 
 typedef std::vector<OTIO_NS::Effect *> EffectVectorDef;
 typedef std::vector<OTIO_NS::Effect *>::iterator EffectVectorIteratorDef;
@@ -28,9 +29,9 @@ OTIO_API Item *Item_create(
         AnyDictionary *metadata,
         EffectVector *effects,
         MarkerVector *markers) {
-    nonstd::optional<OTIO_NS::TimeRange> source_range_optional = nonstd::nullopt;
+    std::optional<OTIO_NS::TimeRange> source_range_optional = std::nullopt;
     if (source_range.valid)
-        source_range_optional = nonstd::optional<OTIO_NS::TimeRange>(
+        source_range_optional = std::optional<OTIO_NS::TimeRange>(
                 CTimeRange_to_CppTimeRange(source_range.value));
 
     std::string name_str = std::string();
@@ -62,16 +63,16 @@ OTIO_API bool Item_overlapping(Item *self) {
     return reinterpret_cast<OTIO_NS::Item *>(self)->overlapping();
 }
 OTIO_API OptionalTimeRange Item_source_range(Item *self) {
-    nonstd::optional<OTIO_NS::TimeRange> timeRangeOptional =
+    std::optional<OTIO_NS::TimeRange> timeRangeOptional =
             reinterpret_cast<OTIO_NS::Item *>(self)->source_range();
-    if (timeRangeOptional == nonstd::nullopt)
+    if (timeRangeOptional == std::nullopt)
         return OptionalTimeRange_create_null();
     return OptionalTimeRange_create(CppTimeRange_to_CTimeRange(timeRangeOptional.value()));
 }
 OTIO_API void Item_set_source_range(Item *self, OptionalTimeRange source_range) {
-    nonstd::optional<OTIO_NS::TimeRange> timeRangeOptional = nonstd::nullopt;
+    std::optional<OTIO_NS::TimeRange> timeRangeOptional = std::nullopt;
     if (source_range.valid)
-        timeRangeOptional = nonstd::optional<OTIO_NS::TimeRange>(
+        timeRangeOptional = std::optional<OTIO_NS::TimeRange>(
                 CTimeRange_to_CppTimeRange(source_range.value));
     reinterpret_cast<OTIO_NS::Item *>(self)->set_source_range(
             timeRangeOptional);
@@ -114,10 +115,10 @@ OTIO_API TimeRange Item_visible_range(Item *self, OTIOErrorStatus *error_status)
 }
 OTIO_API OptionalTimeRange
 Item_trimmed_range_in_parent(Item *self, OTIOErrorStatus *error_status) {
-    nonstd::optional<OTIO_NS::TimeRange> timeRangeOptional =
+    std::optional<OTIO_NS::TimeRange> timeRangeOptional =
             reinterpret_cast<OTIO_NS::Item *>(self)->trimmed_range_in_parent(
                     reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status));
-    if (timeRangeOptional == nonstd::nullopt) return OptionalTimeRange_create_null();
+    if (timeRangeOptional == std::nullopt) return OptionalTimeRange_create_null();
     return OptionalTimeRange_create(CppTimeRange_to_CTimeRange(timeRangeOptional.value()));
 }
 OTIO_API TimeRange Item_range_in_parent(Item *self, OTIOErrorStatus *error_status) {

--- a/src/copentimelineio/mediaReference.cpp
+++ b/src/copentimelineio/mediaReference.cpp
@@ -8,12 +8,13 @@
 #include <opentime/timeRange.h>
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/mediaReference.h>
+#include <optional>
 
 OTIO_API MediaReference *MediaReference_create(
         const char *name, OptionalTimeRange available_range, AnyDictionary *metadata) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional = nonstd::nullopt;
+    std::optional<opentime::TimeRange> timeRangeOptional = std::nullopt;
     if (available_range.valid)
-        timeRangeOptional = nonstd::optional<opentime::TimeRange>(
+        timeRangeOptional = std::optional<opentime::TimeRange>(
                 CTimeRange_to_CppTimeRange(available_range.value));
 
     std::string name_str = std::string();
@@ -28,16 +29,16 @@ OTIO_API MediaReference *MediaReference_create(
             name_str, timeRangeOptional, metadataDictionary));
 }
 OTIO_API OptionalTimeRange MediaReference_available_range(MediaReference *self) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional =
+    std::optional<opentime::TimeRange> timeRangeOptional =
             reinterpret_cast<OTIO_NS::MediaReference *>(self)->available_range();
-    if (timeRangeOptional == nonstd::nullopt) return OptionalTimeRange_create_null();
+    if (timeRangeOptional == std::nullopt) return OptionalTimeRange_create_null();
     return OptionalTimeRange_create(CppTimeRange_to_CTimeRange(timeRangeOptional.value()));
 }
 OTIO_API void MediaReference_set_available_range(
         MediaReference *self, OptionalTimeRange available_range) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional = nonstd::nullopt;
+    std::optional<opentime::TimeRange> timeRangeOptional = std::nullopt;
     if (available_range.valid)
-        timeRangeOptional = nonstd::optional<opentime::TimeRange>(
+        timeRangeOptional = std::optional<opentime::TimeRange>(
                 CTimeRange_to_CppTimeRange(available_range.value));
     reinterpret_cast<OTIO_NS::MediaReference *>(self)->set_available_range(
             timeRangeOptional);

--- a/src/copentimelineio/missingReference.cpp
+++ b/src/copentimelineio/missingReference.cpp
@@ -9,12 +9,13 @@
 #include <opentime/timeRange.h>
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/missingReference.h>
+#include <optional>
 
 OTIO_API MissingReference *MissingReference_create(
         const char *name, OptionalTimeRange available_range, AnyDictionary *metadata) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional = nonstd::nullopt;
+    std::optional<opentime::TimeRange> timeRangeOptional = std::nullopt;
     if (available_range.valid)
-        timeRangeOptional = nonstd::optional<opentime::TimeRange>(
+        timeRangeOptional = std::optional<opentime::TimeRange>(
                 CTimeRange_to_CppTimeRange(available_range.value));
     OTIO_NS::AnyDictionary metadataDictionary = OTIO_NS::AnyDictionary();
     if (metadata != NULL)

--- a/src/copentimelineio/optionalPairRationalTime.cpp
+++ b/src/copentimelineio/optionalPairRationalTime.cpp
@@ -4,50 +4,51 @@
 #include "copentime/util.h"
 #include "copentimelineio/optionalPairRationalTime.h"
 #include <opentime/rationalTime.h>
-#include <opentimelineio/optional.h>
+//#include <opentimelineio/optional.h>
 #include <utility>
+#include <optional>
 
 typedef std::pair<
-        nonstd::optional<opentime::RationalTime>,
-        nonstd::optional<opentime::RationalTime>>
+        std::optional<opentime::RationalTime>,
+        std::optional<opentime::RationalTime>>
         PairDef;
 
 OTIO_API OptionalPairRationalTime *
 OptionalPairRationalTime_create(OptionalRationalTime first, OptionalRationalTime second) {
-    nonstd::optional<opentime::RationalTime> firstRationalTimeOptional =
-            nonstd::nullopt;
-    nonstd::optional<opentime::RationalTime> secondRationalTimeOptional =
-            nonstd::nullopt;
+    std::optional<opentime::RationalTime> firstRationalTimeOptional =
+            std::nullopt;
+    std::optional<opentime::RationalTime> secondRationalTimeOptional =
+            std::nullopt;
     if (first.valid) {
         opentime::RationalTime rationalTime = CRationalTime_to_CppRationalTime(first.value);
         firstRationalTimeOptional =
-                nonstd::optional<opentime::RationalTime>(rationalTime);
+                std::optional<opentime::RationalTime>(rationalTime);
     }
     if (second.valid) {
         opentime::RationalTime rationalTime = CRationalTime_to_CppRationalTime(second.value);
         secondRationalTimeOptional =
-                nonstd::optional<opentime::RationalTime>(rationalTime);
+                std::optional<opentime::RationalTime>(rationalTime);
     }
     return reinterpret_cast<OptionalPairRationalTime *>(
             new std::pair<
-                    nonstd::optional<opentime::RationalTime>,
-                    nonstd::optional<opentime::RationalTime>>(
+                    std::optional<opentime::RationalTime>,
+                    std::optional<opentime::RationalTime>>(
                     firstRationalTimeOptional, secondRationalTimeOptional));
 }
 
 OTIO_API OptionalRationalTime OptionalPairRationalTime_first(OptionalPairRationalTime *self) {
-    nonstd::optional<opentime::RationalTime> rationalTimeOptional =
+    std::optional<opentime::RationalTime> rationalTimeOptional =
             reinterpret_cast<PairDef *>(self)->first;
-    if (rationalTimeOptional == nonstd::nullopt) return OptionalRationalTime_create_null();
+    if (rationalTimeOptional == std::nullopt) return OptionalRationalTime_create_null();
     opentime::RationalTime rtValue = rationalTimeOptional.value();
     return OptionalRationalTime_create(CppRationalTime_to_CRationalTime(rtValue));
 }
 
 OTIO_API OptionalRationalTime
 OptionalPairRationalTime_second(OptionalPairRationalTime *self) {
-    nonstd::optional<opentime::RationalTime> rationalTimeOptional =
+    std::optional<opentime::RationalTime> rationalTimeOptional =
             reinterpret_cast<PairDef *>(self)->second;
-    if (rationalTimeOptional == nonstd::nullopt) return OptionalRationalTime_create_null();
+    if (rationalTimeOptional == std::nullopt) return OptionalRationalTime_create_null();
     opentime::RationalTime rtValue = rationalTimeOptional.value();
     return OptionalRationalTime_create(CppRationalTime_to_CRationalTime(rtValue));
 }

--- a/src/copentimelineio/safely_typed_any.cpp
+++ b/src/copentimelineio/safely_typed_any.cpp
@@ -6,7 +6,7 @@
 #include <opentime/rationalTime.h>
 #include <opentime/timeRange.h>
 #include <opentime/timeTransform.h>
-#include <opentimelineio/any.h>
+//#include <opentimelineio/any.h>
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/safely_typed_any.h>
 #include <opentimelineio/serializableObject.h>
@@ -14,123 +14,124 @@
 #include <string.h>
 #include <utility>
 #include <vector>
+#include <any>
 
 OTIO_API Any *create_safely_typed_any_bool(bool boolValue) {
-    OTIO_NS::any anyValue =
+    std::any anyValue =
             OTIO_NS::create_safely_typed_any(std::move(boolValue));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 OTIO_API Any *create_safely_typed_any_int(int intValue) {
-    OTIO_NS::any anyValue =
+    std::any anyValue =
             OTIO_NS::create_safely_typed_any(std::move(intValue));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 OTIO_API Any *create_safely_typed_any_int64(int64_t int64Value) {
-    OTIO_NS::any anyValue =
+    std::any anyValue =
             OTIO_NS::create_safely_typed_any(std::move(int64Value));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 OTIO_API Any *create_safely_typed_any_double(double doubleValue) {
-    OTIO_NS::any anyValue =
+    std::any anyValue =
             OTIO_NS::create_safely_typed_any(std::move(doubleValue));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 OTIO_API Any *create_safely_typed_any_string(const char *stringValue) {
     std::string str = stringValue;
-    OTIO_NS::any anyValue =
+    std::any anyValue =
             OTIO_NS::create_safely_typed_any(std::move(str));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 OTIO_API Any *create_safely_typed_any_rational_time(RationalTime rationalTimeValue) {
-    OTIO_NS::any anyValue = OTIO_NS::create_safely_typed_any(std::move(
+    std::any anyValue = OTIO_NS::create_safely_typed_any(std::move(
             CRationalTime_to_CppRationalTime(rationalTimeValue)));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 OTIO_API Any *create_safely_typed_any_time_range(TimeRange timeRangeValue) {
-    OTIO_NS::any anyValue = OTIO_NS::create_safely_typed_any(
+    std::any anyValue = OTIO_NS::create_safely_typed_any(
             CTimeRange_to_CppTimeRange(timeRangeValue));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 OTIO_API Any *
 create_safely_typed_any_time_transform(TimeTransform timeTransformValue) {
-    OTIO_NS::any anyValue = OTIO_NS::create_safely_typed_any(std::move(
+    std::any anyValue = OTIO_NS::create_safely_typed_any(std::move(
             CTimeTransform_to_CppTimeTransform(timeTransformValue)));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 OTIO_API Any *create_safely_typed_any_any_vector(AnyVector *anyVectorValue) {
-    OTIO_NS::any anyValue = OTIO_NS::create_safely_typed_any(
+    std::any anyValue = OTIO_NS::create_safely_typed_any(
             std::move(*reinterpret_cast<OTIO_NS::AnyVector *>(anyVectorValue)));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 OTIO_API Any *
 create_safely_typed_any_any_dictionary(AnyDictionary *anyDictionaryValue) {
-    OTIO_NS::any anyValue = OTIO_NS::create_safely_typed_any(std::move(
+    std::any anyValue = OTIO_NS::create_safely_typed_any(std::move(
             *reinterpret_cast<OTIO_NS::AnyDictionary *>(anyDictionaryValue)));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 OTIO_API Any *create_safely_typed_any_serializable_object(
         OTIOSerializableObject *serializableObjectValue) {
-    OTIO_NS::any anyValue = OTIO_NS::create_safely_typed_any(
+    std::any anyValue = OTIO_NS::create_safely_typed_any(
             reinterpret_cast<OTIO_NS::SerializableObject *>(
                     serializableObjectValue));
-    return reinterpret_cast<Any *>(new OTIO_NS::any(anyValue));
+    return reinterpret_cast<Any *>(new std::any(anyValue));
 }
 
 OTIO_API bool safely_cast_bool_any(Any *a) {
     return OTIO_NS::safely_cast_bool_any(
-            *reinterpret_cast<OTIO_NS::any *>(a));
+            *reinterpret_cast<std::any *>(a));
 }
 OTIO_API int safely_cast_int_any(Any *a) {
     return OTIO_NS::safely_cast_int_any(
-            *reinterpret_cast<OTIO_NS::any *>(a));
+            *reinterpret_cast<std::any *>(a));
 }
 OTIO_API int64_t safely_cast_int64_any(Any *a) {
     return OTIO_NS::safely_cast_int64_any(
-            *reinterpret_cast<OTIO_NS::any *>(a));
+            *reinterpret_cast<std::any *>(a));
 }
 OTIO_API double safely_cast_double_any(Any *a) {
     return OTIO_NS::safely_cast_double_any(
-            *reinterpret_cast<OTIO_NS::any *>(a));
+            *reinterpret_cast<std::any *>(a));
 }
 OTIO_API const char *safely_cast_string_any(Any *a) {
     std::string returnStr = OTIO_NS::safely_cast_string_any(
-            *reinterpret_cast<OTIO_NS::any *>(a));
+            *reinterpret_cast<std::any *>(a));
     return strdup(returnStr.c_str());
 }
 OTIO_API RationalTime safely_cast_rational_time_any(Any *a) {
     opentime::RationalTime rationalTime =
             OTIO_NS::safely_cast_rational_time_any(
-                    *reinterpret_cast<OTIO_NS::any *>(a));
+                    *reinterpret_cast<std::any *>(a));
     return CppRationalTime_to_CRationalTime(rationalTime);
 }
 OTIO_API TimeRange safely_cast_time_range_any(Any *a) {
     opentime::TimeRange timeRange = OTIO_NS::safely_cast_time_range_any(
-            *reinterpret_cast<OTIO_NS::any *>(a));
+            *reinterpret_cast<std::any *>(a));
     return CppTimeRange_to_CTimeRange(timeRange);
 }
 OTIO_API TimeTransform safely_cast_time_transform_any(Any *a) {
     opentime::TimeTransform timeTransform =
             OTIO_NS::safely_cast_time_transform_any(
-                    *reinterpret_cast<OTIO_NS::any *>(a));
+                    *reinterpret_cast<std::any *>(a));
     return CppTimeTransform_to_CTimeTransform(timeTransform);
 }
 OTIO_API OTIOSerializableObject *safely_cast_retainer_any(Any *a) {
     return reinterpret_cast<OTIOSerializableObject *>(
             OTIO_NS::safely_cast_retainer_any(
-                    *reinterpret_cast<OTIO_NS::any *>(a)));
+                    *reinterpret_cast<std::any *>(a)));
 }
 
 OTIO_API AnyDictionary *safely_cast_any_dictionary_any(Any *a) {
     OTIO_NS::AnyDictionary anyDictionary =
             OTIO_NS::safely_cast_any_dictionary_any(
-                    *reinterpret_cast<OTIO_NS::any *>(a));
+                    *reinterpret_cast<std::any *>(a));
     return reinterpret_cast<AnyDictionary *>(
             new OTIO_NS::AnyDictionary(anyDictionary));
 }
 
 OTIO_API AnyVector *safely_cast_any_vector_any(Any *a) {
     OTIO_NS::AnyVector anyVector = OTIO_NS::safely_cast_any_vector_any(
-            *reinterpret_cast<OTIO_NS::any *>(a));
+            *reinterpret_cast<std::any *>(a));
     return reinterpret_cast<AnyVector *>(new OTIO_NS::AnyVector(anyVector));
 }
 

--- a/src/copentimelineio/safely_typed_any.cpp
+++ b/src/copentimelineio/safely_typed_any.cpp
@@ -6,7 +6,6 @@
 #include <opentime/rationalTime.h>
 #include <opentime/timeRange.h>
 #include <opentime/timeTransform.h>
-//#include <opentimelineio/any.h>
 #include <opentimelineio/anyDictionary.h>
 #include <opentimelineio/safely_typed_any.h>
 #include <opentimelineio/serializableObject.h>

--- a/src/copentimelineio/serializableObject.cpp
+++ b/src/copentimelineio/serializableObject.cpp
@@ -54,6 +54,7 @@ SerializableObject_to_json_file(
         ->to_json_file(
             file_name,
             reinterpret_cast<OTIO_NS::ErrorStatus*>(error_status),
+            {},
             indent);
 }
 
@@ -65,6 +66,7 @@ SerializableObject_to_json_string(
         reinterpret_cast<OTIO_NS::SerializableObject*>(self)
             ->to_json_string(
                 reinterpret_cast<OTIO_NS::ErrorStatus*>(error_status),
+                {},
                 indent);
     return strdup(returnStr.c_str());
 }

--- a/src/copentimelineio/serialization.cpp
+++ b/src/copentimelineio/serialization.cpp
@@ -4,11 +4,13 @@
 #include "copentimelineio/serialization.h"
 #include <opentimelineio/serialization.h>
 #include <string.h>
+#include <any>
 
 OTIO_API const char *serialize_json_to_string(
         Any *value, OTIOErrorStatus *error_status, int indent) {
     std::string returnStr = OTIO_NS::serialize_json_to_string(
-            *reinterpret_cast<OTIO_NS::any *>(value),
+            *reinterpret_cast<std::any *>(value),
+            {},
             reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status),
             indent);
     return strdup(returnStr.c_str());
@@ -20,8 +22,9 @@ OTIO_API bool serialize_json_to_file(
         OTIOErrorStatus *error_status,
         int indent) {
     return OTIO_NS::serialize_json_to_file(
-            reinterpret_cast<OTIO_NS::any *>(value),
+            reinterpret_cast<std::any *>(value),
             file_name,
+            {},
             reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status),
             indent);
 }

--- a/src/copentimelineio/stack.cpp
+++ b/src/copentimelineio/stack.cpp
@@ -10,6 +10,7 @@
 #include <opentimelineio/composable.h>
 #include <opentimelineio/errorStatus.h>
 #include <opentimelineio/stack.h>
+#include <optional>
 
 typedef std::vector<OTIO_NS::Effect *> EffectVectorDef;
 typedef std::vector<OTIO_NS::Effect *>::iterator EffectVectorIteratorDef;
@@ -25,9 +26,9 @@ OTIO_API Stack *Stack_create(
         AnyDictionary *metadata,
         EffectVector *effects,
         MarkerVector *markers) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional = nonstd::nullopt;
+    std::optional<opentime::TimeRange> timeRangeOptional = std::nullopt;
     if (source_range.valid)
-        timeRangeOptional = nonstd::optional<opentime::TimeRange>(
+        timeRangeOptional = std::optional<opentime::TimeRange>(
                 CTimeRange_to_CppTimeRange(source_range.value));
 
     std::string name_str = std::string();

--- a/src/copentimelineio/timeline.cpp
+++ b/src/copentimelineio/timeline.cpp
@@ -11,6 +11,7 @@
 #include <opentimelineio/timeline.h>
 #include <opentimelineio/track.h>
 #include <vector>
+#include <optional>
 
 typedef std::vector<OTIO_NS::Track *> TrackVectorDef;
 typedef std::vector<OTIO_NS::Track *>::iterator TrackVectorIteratorDef;
@@ -27,9 +28,9 @@ OTIO_API Timeline *Timeline_create(
         metadataDictionary =
                 *reinterpret_cast<OTIO_NS::AnyDictionary *>(metadata);
 
-    nonstd::optional<opentime::RationalTime> rationalTimeOptional = nonstd::nullopt;
+    std::optional<opentime::RationalTime> rationalTimeOptional = std::nullopt;
     if (global_start_time.valid)
-        rationalTimeOptional = nonstd::optional<opentime::RationalTime>(
+        rationalTimeOptional = std::optional<opentime::RationalTime>(
                 CRationalTime_to_CppRationalTime(global_start_time.value));
     return reinterpret_cast<Timeline *>(new OTIO_NS::Timeline(
             name_str, rationalTimeOptional, metadataDictionary));
@@ -46,17 +47,17 @@ OTIO_API void Timeline_set_tracks(Timeline *self, Stack *stack) {
 }
 
 OTIO_API OptionalRationalTime Timeline_global_start_time(Timeline *self) {
-    nonstd::optional<opentime::RationalTime> rationalTimeOptional =
+    std::optional<opentime::RationalTime> rationalTimeOptional =
             reinterpret_cast<OTIO_NS::Timeline *>(self)->global_start_time();
-    if (rationalTimeOptional == nonstd::nullopt) return OptionalRationalTime_create_null();
+    if (rationalTimeOptional == std::nullopt) return OptionalRationalTime_create_null();
     return OptionalRationalTime_create(CppRationalTime_to_CRationalTime(rationalTimeOptional.value()));
 }
 
 OTIO_API void Timeline_set_global_start_time(
         Timeline *self, OptionalRationalTime global_start_time) {
-    nonstd::optional<opentime::RationalTime> rationalTimeOptional = nonstd::nullopt;
+    std::optional<opentime::RationalTime> rationalTimeOptional = std::nullopt;
     if (global_start_time.valid)
-        rationalTimeOptional = nonstd::optional<opentime::RationalTime>(
+        rationalTimeOptional = std::optional<opentime::RationalTime>(
                 CRationalTime_to_CppRationalTime(global_start_time.value));
     reinterpret_cast<OTIO_NS::Timeline *>(self)->set_global_start_time(
             rationalTimeOptional);

--- a/src/copentimelineio/track.cpp
+++ b/src/copentimelineio/track.cpp
@@ -12,6 +12,7 @@
 #include <opentimelineio/track.h>
 #include <string.h>
 #include <utility>
+#include <optional>
 
 typedef std::map<OTIO_NS::Composable *, opentime::TimeRange>::iterator
         MapComposableTimeRangeIteratorDef;
@@ -19,8 +20,8 @@ typedef std::map<OTIO_NS::Composable *, opentime::TimeRange>
         MapComposableTimeRangeDef;
 
 typedef std::pair<
-        nonstd::optional<opentime::RationalTime>,
-        nonstd::optional<opentime::RationalTime>>
+        std::optional<opentime::RationalTime>,
+        std::optional<opentime::RationalTime>>
         OptionalPairRationalTimeDef;
 typedef std::pair<
         OTIO_NS::Composable::Retainer<OTIO_NS::Composable>,
@@ -46,9 +47,9 @@ OTIO_API Track *Track_create(
         OptionalTimeRange source_range,
         const char *kind,
         AnyDictionary *metadata) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional = nonstd::nullopt;
+    std::optional<opentime::TimeRange> timeRangeOptional = std::nullopt;
     if (source_range.valid)
-        timeRangeOptional = nonstd::optional<opentime::TimeRange>(
+        timeRangeOptional = std::optional<opentime::TimeRange>(
                 CTimeRange_to_CppTimeRange(source_range.value));
 
     std::string name_str = std::string();

--- a/src/copentimelineio/transition.cpp
+++ b/src/copentimelineio/transition.cpp
@@ -10,6 +10,7 @@
 #include <opentimelineio/errorStatus.h>
 #include <opentimelineio/transition.h>
 #include <string.h>
+#include <optional>
 
 const char *TransitionType_SMPTE_Dissolve =
         OTIO_NS::Transition::Type::SMPTE_Dissolve;
@@ -86,19 +87,19 @@ Transition_duration(Transition *self, OTIOErrorStatus *error_status) {
 }
 OTIO_API OptionalTimeRange
 Transition_range_in_parent(Transition *self, OTIOErrorStatus *error_status) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional =
+    std::optional<opentime::TimeRange> timeRangeOptional =
             reinterpret_cast<OTIO_NS::Transition *>(self)->range_in_parent(
                     reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status));
-    if (timeRangeOptional == nonstd::nullopt) return OptionalTimeRange_create_null();
+    if (timeRangeOptional == std::nullopt) return OptionalTimeRange_create_null();
     return OptionalTimeRange_create(CppTimeRange_to_CTimeRange(timeRangeOptional.value()));
 }
 OTIO_API OptionalTimeRange Transition_trimmed_range_in_parent(
         Transition *self, OTIOErrorStatus *error_status) {
-    nonstd::optional<opentime::TimeRange> timeRangeOptional =
+    std::optional<opentime::TimeRange> timeRangeOptional =
             reinterpret_cast<OTIO_NS::Transition *>(self)
                     ->trimmed_range_in_parent(
                             reinterpret_cast<OTIO_NS::ErrorStatus *>(error_status));
-    if (timeRangeOptional == nonstd::nullopt) return OptionalTimeRange_create_null();
+    if (timeRangeOptional == std::nullopt) return OptionalTimeRange_create_null();
     return OptionalTimeRange_create(CppTimeRange_to_CTimeRange(timeRangeOptional.value()));
 }
 OTIO_API const char *Transition_name(Transition *self) {


### PR DESCRIPTION
This matches the c++17 branch changes to OpenTimelineIO. Specifically replacing the custom any class with std::any and optional with std::optional.

NOTE: The json version schema feature has NOT been ported and instead the new schema_version_map has been hardcoded to an empty map.