### PR TITLE
replace the use of 'class' with 'struct' in unknownSchema.h

### DIFF
--- a/include/copentimelineio/unknownSchema.h
+++ b/include/copentimelineio/unknownSchema.h
@@ -12,7 +12,7 @@
 # define OTIO_API
 #endif
 
-typedef class UnknownSchema UnknownSchema;
+typedef struct UnknownSchema UnknownSchema;
 
 OTIO_API UnknownSchema *UnknownSchema_create(
         const char *original_schema_name, int original_schema_version);


### PR DESCRIPTION
There was an unexpected use of `class` in the unknownSchema.h header. It has been replaced with `struct` and confirmed all tests still succeed as intended.